### PR TITLE
enhancement: Attestation signatures

### DIFF
--- a/src/base/Query.sol
+++ b/src/base/Query.sol
@@ -36,7 +36,7 @@ abstract contract Query is IQuery {
      */
     function verify(
         address module,
-        address[] memory authorities,
+        address[] calldata authorities,
         uint256 threshold
     )
         external

--- a/src/interface/IAttestation.sol
+++ b/src/interface/IAttestation.sol
@@ -38,7 +38,7 @@ struct AttestationRequest {
 struct DelegatedAttestationRequest {
     bytes32 schema; // The unique identifier of the schema.
     AttestationRequestData data; // The arguments of the attestation request.
-    EIP712Signature signature; // The EIP712 signature data.
+    bytes signature; // The EIP712 signature data.
     address attester; // The attesting account.
 }
 
@@ -56,7 +56,7 @@ struct MultiAttestationRequest {
 struct MultiDelegatedAttestationRequest {
     bytes32 schema; // The unique identifier of the schema.
     AttestationRequestData[] data; // The arguments of the attestation requests.
-    EIP712Signature[] signatures; // The EIP712 signatures data. Please note that the signatures are assumed to be signed with increasing nonces.
+    bytes[] signatures; // The EIP712 signatures data. Please note that the signatures are assumed to be signed with increasing nonces.
     address attester; // The attesting account.
 }
 
@@ -82,7 +82,7 @@ struct RevocationRequest {
 struct DelegatedRevocationRequest {
     bytes32 schema; // The unique identifier of the schema.
     RevocationRequestData data; // The arguments of the revocation request.
-    EIP712Signature signature; // The EIP712 signature data.
+    bytes signature; // The EIP712 signature data.
     address revoker; // The revoking account.
 }
 
@@ -100,7 +100,7 @@ struct MultiRevocationRequest {
 struct MultiDelegatedRevocationRequest {
     bytes32 schema; // The unique identifier of the schema.
     RevocationRequestData[] data; // The arguments of the revocation requests.
-    EIP712Signature[] signatures; // The EIP712 signatures data. Please note that the signatures are assumed to be signed with increasing nonces.
+    bytes[] signatures; // The EIP712 signatures data. Please note that the signatures are assumed to be signed with increasing nonces.
     address revoker; // The revoking account.
 }
 

--- a/test/Attestation.t.sol
+++ b/test/Attestation.t.sol
@@ -104,7 +104,7 @@ contract AttestationTest is BaseTest {
         DelegatedAttestationRequest memory req = DelegatedAttestationRequest({
             schema: defaultSchema1,
             data: attData,
-            signature: sig,
+            signature: abi.encode(sig),
             attester: address(attester)
         });
 
@@ -142,12 +142,17 @@ contract AttestationTest is BaseTest {
 
         EIP712Signature[] memory sigs = instancel1.signAttestation(defaultSchema1, auth1k, attArray);
 
+        bytes[] memory sigsBytes = new bytes[](sigs.length);
+        for (uint256 index = 0; index < sigs.length; index++) {
+            sigsBytes[index] = abi.encode(sigs[index]);
+        }
+
         MultiDelegatedAttestationRequest[] memory reqs = new MultiDelegatedAttestationRequest[](1);
         MultiDelegatedAttestationRequest memory req1 = MultiDelegatedAttestationRequest({
             schema: defaultSchema1,
             data: attArray,
             attester: vm.addr(auth1k),
-            signatures: sigs
+            signatures: sigsBytes
         });
         reqs[0] = req1;
 

--- a/test/resolvers/ValueResolver.t.sol
+++ b/test/resolvers/ValueResolver.t.sol
@@ -37,7 +37,7 @@ contract ValueResolverTest is BaseTest {
         DelegatedAttestationRequest memory req = DelegatedAttestationRequest({
             schema: schema,
             data: attData,
-            signature: signature,
+            signature: abi.encode(signature),
             attester: vm.addr(auth1k)
         });
 

--- a/test/utils/BaseUtils.sol
+++ b/test/utils/BaseUtils.sol
@@ -84,7 +84,7 @@ library RegistryTestLib {
         DelegatedAttestationRequest memory req = DelegatedAttestationRequest({
             schema: schemaId,
             data: attData,
-            signature: signature,
+            signature: abi.encode(signature),
             attester: getAddr(attesterKey)
         });
 
@@ -132,7 +132,6 @@ library RegistryTestLib {
                 schemaUid: schemaId,
                 nonce: nonce + i
             });
-            console2.logBytes32(digest);
 
             (uint8 v, bytes32 r, bytes32 s) = Vm(VM_ADDR).sign(attesterPk, digest);
             sig[i] = EIP712Signature({ v: v, r: r, s: s });
@@ -159,7 +158,7 @@ library RegistryTestLib {
         DelegatedRevocationRequest memory req = DelegatedRevocationRequest({
             schema: schemaId,
             data: revoke,
-            signature: signature,
+            signature: abi.encode(signature),
             revoker: getAddr(attesterPk)
         });
         instance.registry.revoke(req);


### PR DESCRIPTION
### msg.sender attestations

The registry now supports _native_ attestations and revocations. Instead of only allowing for signed (EOA/`ERC-1271`) attestations, they can now be issued via normal transaction. the attestation will be assigned to `msg.sender`

### support for non v,r,s signatures
registry now supports attestations / revocations that use arbitrary bytes signatures for `ERC-1271`. 
This allow multisigs accounts like safe to sign attestations/revocations with multiple signatures that would not fit into            
`uint8 v, bytes32 r, bytes32 s`. Further more, this would allow `ERC-1271 `endpoints to validate other signature patters like `BLS`  signatures, or custom validation logic.
This feature addresses Issue: https://github.com/rhinestonewtf/registry/issues/15