### PR TITLE
Chore: cleanup repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img align="right" width="150" height="150" top="100" src="https://docs-9d8fk274h-rhinestone.vercel.app/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Frhinestone.d2796f13.png&w=2048&q=75">
 
-# Registry  [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) ![solidity](https://img.shields.io/badge/solidity-^0.8.19-lightgrey) [![Foundry][foundry-badge]][foundry]
+# Registry [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) ![solidity](https://img.shields.io/badge/solidity-^0.8.19-lightgrey) [![Foundry][foundry-badge]][foundry]
+
 [foundry]: https://getfoundry.sh
 [foundry-badge]: https://img.shields.io/badge/Built%20with-Foundry-FFDB1C.svg
 
@@ -8,113 +9,117 @@ This Contract is in active development. Do not use this in Prod!
 
 ## Intro
 
-Account abstraction (or smart accounts) will deliver three key enhancements for the Ethereum ecosystem; 
-improved UX, enhanced user security and greater wallet extensibility. Modular smart accounts are the next 
-frontier for supercharging these deliverables. However, it also opens up a number of new challenges that 
-could drastically undermine the objective by opening up a plethora of new attack vectors and security concerns for accounts. 
+Account abstraction (or smart accounts) will deliver three key enhancements for the Ethereum ecosystem;
+improved UX, enhanced user security and greater wallet extensibility. Modular smart accounts are the next
+frontier for supercharging these deliverables. However, it also opens up a number of new challenges that
+could drastically undermine the objective by opening up a plethora of new attack vectors and security concerns for accounts.
 
-
-The [Rhinestone Registry] aims to solve this concern by providing a means of verifying the legitimacy and 
-security of independently built smart account modules for deployment and use across any integrated 
-smart account. [Rhinestone Registry] is a free, open and permissionless registry and verifications 
-system for smart account modules on the Ethereum platform. With an emphasis on contract security and 
-transparency, it allows attesters to register, verify, and dispatch verification statuses across 
+The [Rhinestone Registry] aims to solve this concern by providing a means of verifying the legitimacy and
+security of independently built smart account modules for deployment and use across any integrated
+smart account. [Rhinestone Registry] is a free, open and permissionless registry and verifications
+system for smart account modules on the Ethereum platform. With an emphasis on contract security and
+transparency, it allows attesters to register, verify, and dispatch verification statuses across
 various EVM chains.
 
-
 ## Core Principles
+
 ### Attestations
-[Attestations](./docs/Attestation.md) represent digitally documented assertions made by any entity 
-about the security poture of account abstraction modules, 
-serving as a seal of authenticity for the associated data. An entity known as an 
-Attestor forms these records, authenticating them with their Ethereum wallet 
-and then registering them on the Ethereum blockchain. The accessibility of 
-these attestations for verification is universal, provided one has access 
+
+[Attestations](./docs/Attestation.md) represent digitally documented assertions made by any entity
+about the security poture of account abstraction modules,
+serving as a seal of authenticity for the associated data. An entity known as an
+Attestor forms these records, authenticating them with their Ethereum wallet
+and then registering them on the Ethereum blockchain. The accessibility of
+these attestations for verification is universal, provided one has access
 to the Ethereum blockchain and the unique UID of the attestation.
 
-An attestation consists of two primary elements: the schema and the 
-attestation data. The schema acts as a standardized structure for 
-creating and validating attestations, defining the data types, 
-format, and composition. The Rhinestone Registry uses Solidity 
-ABI types as acceptable fields in these schemas. The attestation 
-data represents the actual information subject to attestation. 
-To be classified as a valid attestation, it should adhere to the 
+An attestation consists of two primary elements: the schema and the
+attestation data. The schema acts as a standardized structure for
+creating and validating attestations, defining the data types,
+format, and composition. The Rhinestone Registry uses Solidity
+ABI types as acceptable fields in these schemas. The attestation
+data represents the actual information subject to attestation.
+To be classified as a valid attestation, it should adhere to the
 structure defined in the schema.
 
-The significance of attestations lies in their ability to 
-facilitate trust and credibility within the blockchain. In 
-scenarios lacking physical interaction or presence, verifying 
-the veracity or reliability of information can be demanding. 
-Attestations address this challenge by providing third-party 
-validation and a cryptographically signed confirmation of 
-information authenticity, thus enhancing the information's 
+The significance of attestations lies in their ability to
+facilitate trust and credibility within the blockchain. In
+scenarios lacking physical interaction or presence, verifying
+the veracity or reliability of information can be demanding.
+Attestations address this challenge by providing third-party
+validation and a cryptographically signed confirmation of
+information authenticity, thus enhancing the information's
 trustworthiness for others.
 
 ### Schemas
-[Schemas](./docs/Schema.md) represent predefined structures utilized for the formation and 
-verification of attestations. They define the data types, format, and 
-composition of an attestation. The Rhinestone Registry accepts Solidity 
-ABI types as acceptable fields for schemas. Schemas play an essential 
-role as they establish a shared format and structure for attestation 
-data, enabling the creation and verification of various attestations 
-in a trustless fashion. This functionality paves the way for 
+
+[Schemas](./docs/Schema.md) represent predefined structures utilized for the formation and
+verification of attestations. They define the data types, format, and
+composition of an attestation. The Rhinestone Registry accepts Solidity
+ABI types as acceptable fields for schemas. Schemas play an essential
+role as they establish a shared format and structure for attestation
+data, enabling the creation and verification of various attestations
+in a trustless fashion. This functionality paves the way for
 interoperability and composability amongst different attestation protocols and solutions.
 
 ### Attestors
-Attestors refer to individuals or organizations responsible for 
-creating and signing attestations. They add the attestation to the 
-Ethereum blockchain, making it available for verification. Any 
-individual owning an Ethereum wallet can become an Attestor and 
+
+Attestors refer to individuals or organizations responsible for
+creating and signing attestations. They add the attestation to the
+Ethereum blockchain, making it available for verification. Any
+individual owning an Ethereum wallet can become an Attestor and
 can formulate attestations for a variety of purposes.
 
 ### Modules
-Modules are smart contracts that act as modular components that can be added to smart accounts. 
-The registry is agnostic towards smart account or module implementations. Modules addresses and 
+
+Modules are smart contracts that act as modular components that can be added to smart accounts.
+The registry is agnostic towards smart account or module implementations. Modules addresses and
 deployment metadata are stored on the registry.
 
 Modules are registered on the Rhinestone Registry by [deploying](./docs/ModulesRegistration.md) the Module Bytecode with `CREATE2`
 
-
 ### Cross-Chain Consistency
+
 For account abstraction modules that can be used [across multiple Ethereum](./docs/L2Propagation.md) chains,
-the Rhinestone Registry can ensure the consistency of modules across these chains. 
-This feature will prevent versioning issues, guaranteeing that users experience the same level of security and functionality, 
+the Rhinestone Registry can ensure the consistency of modules across these chains.
+This feature will prevent versioning issues, guaranteeing that users experience the same level of security and functionality,
 irrespective of the chain they're on.
 
 ### Users
-Users represent entities that depend on attestations to inform 
-decisions or initiate actions. They utilize the information enclosed 
-within the attestation to confirm its authenticity and integrity. The 
-backing for these attestations often lies in the reputation and 
+
+Users represent entities that depend on attestations to inform
+decisions or initiate actions. They utilize the information enclosed
+within the attestation to confirm its authenticity and integrity. The
+backing for these attestations often lies in the reputation and
 trustworthiness of the Attestor.
 
 ### Ethereum ABI Types
-The Ethereum Application Binary Interface (ABI) stipulates the data 
-types that can be incorporated in smart contracts and other Ethereum transactions. 
+
+The Ethereum Application Binary Interface (ABI) stipulates the data
+types that can be incorporated in smart contracts and other Ethereum transactions.
 EAS accepts ABI types as valid fields for schemas.
 
 ## Architecture
 
-The Rhinestone Registry is designed as a permissionless hyperstructure. 
-This architecture enables the registry to effectively manage and coordinate various types of smart contracts, 
-spanning multiple developers and authorities. With this level of interconnectedness, smart contracts can freely interact with each other and with 
-various authorities, opening up a world of possibilities for rich, complex interactions. It promotes a decentralized, collaborative environment, 
+The Rhinestone Registry is designed as a permissionless hyperstructure.
+This architecture enables the registry to effectively manage and coordinate various types of smart contracts,
+spanning multiple developers and authorities. With this level of interconnectedness, smart contracts can freely interact with each other and with
+various authorities, opening up a world of possibilities for rich, complex interactions. It promotes a decentralized, collaborative environment,
 where entities can share, validate, and verify smart contracts across chains.
-
 
 ![Architecture](./public/docs/architecture.png)
 
-
-
 ### Prerequisites
+
 - Solidity version 0.8.19 or later
 - External dependencies: Hashi's Yaho.sol and Hashi's Yaru.sol
 
-
 ## Contribute
+
 For feature of change requests, feel free to get in touch with us, or open PRs
 
 ## Credits
+
 - Rhinestone Registry is leveraging an attestation logic inspired by EAS
 
 ## Authors ✨
@@ -125,7 +130,7 @@ For feature of change requests, feel free to get in touch with us, or open PRs
 <table>
   <tr>
     <td align="center"><a href="http://twitter.com/zeroknotsETH/"><img src="https://pbs.twimg.com/profile_images/1639062011387715590/bNmZ5Gpf_400x400.jpg" width="100px;" alt=""/><br /><sub><b>zeroknots</b></sub></a><br /><a href="https://github.com/rhinestonewtf/registry/commits?author=zeroknots" title="Code">💻</a></td>
-    <td align="center"><a href="https://twitter.com/abstractooor"><img src="https://pbs.twimg.com/profile_images/1563803892231675905/9heafdY__400x400.jpg" width="100px;" alt=""/><br /><sub><b>Konrad</b></sub></a><br /><a href="https://github.com/rhinestonewtf/registry/commits?author=kopy-kat" title="Code">💻<</a> </td>
+    <td align="center"><a href="https://twitter.com/abstractooor"><img src="https://avatars.githubusercontent.com/u/26718079?v=4" width="100px;" alt=""/><br /><sub><b>Konrad</b></sub></a><br /><a href="https://github.com/rhinestonewtf/registry/commits?author=kopy-kat" title="Code">💻<</a> </td>
     
   </tr>
 </table>

--- a/src/Common.sol
+++ b/src/Common.sol
@@ -29,7 +29,7 @@ struct EIP712Signature {
  */
 struct AttestationRecord {
     bytes32 uid; // A unique identifier of the attestation.
-    bytes32 schema; // The unique identifier of the schema.
+    bytes32 schemaUID; // The unique identifier of the schema.
     bytes32 refUID; // The UID of the related attestation.
     address subject; // The recipient of the attestation i.e. module
     address attester; // The attester/sender of the attestation.
@@ -46,8 +46,8 @@ struct ModuleRecord {
     address implementation; // The deployed contract address
     bytes32 codeHash; // The hash of the contract code
     bytes32 deployParamsHash; // The hash of the parameters used to deploy the contract
-    bytes32 schemaId; // The id of the schema related to this module
-    address sender; // The address of the sender who deployed the contract
+    bytes32 schemaUID; // The id of the schema related to this module
+    address deployer; // The address of the sender who deployed the contract
     bytes data; // Additional data related to the contract deployment
 }
 

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -33,13 +33,13 @@ contract Registry is Schema, Query, Attestation, Module {
         return super.getBridges(uid);
     }
 
-    function getSchema(bytes32 uid)
+    function getSchema(bytes32 schemaUID)
         public
         view
         override(Attestation, Module, Schema)
         returns (SchemaRecord memory)
     {
-        return super.getSchema(uid);
+        return super.getSchema(schemaUID);
     }
 
     function _getAttestation(

--- a/src/base/Attestation.sol
+++ b/src/base/Attestation.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.19;
 
-import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import "../eip712/EIP712Verifier.sol";
 import "../interface/IAttestation.sol";
 import "./Schema.sol";
 import "./Module.sol";
 
-import {ModuleDeploymentLib} from "../lib/ModuleDeploymentLib.sol";
+import { ModuleDeploymentLib } from "../lib/ModuleDeploymentLib.sol";
 
 // Hashi's contract to dispatch messages to L2
 import "hashi/Yaho.sol";
@@ -15,7 +15,9 @@ import "hashi/Yaho.sol";
 // Hashi's contract to receive messages from L1
 import "hashi/Yaru.sol";
 
-import {AccessDenied, NotFound, NO_EXPIRATION_TIME, InvalidLength, uncheckedInc} from "../Common.sol";
+import {
+    AccessDenied, NotFound, NO_EXPIRATION_TIME, InvalidLength, uncheckedInc
+} from "../Common.sol";
 
 import "forge-std/console2.sol";
 
@@ -34,10 +36,9 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
     using Address for address payable;
     using ModuleDeploymentLib for address;
 
-    mapping(bytes32 uid => AttestationRecord attestation)
-        internal _attestations;
-    mapping(address module => mapping(address authority => bytes32 attestationId))
-        internal _moduleToAuthorityToAttestations;
+    mapping(bytes32 uid => AttestationRecord attestation) internal _attestations;
+    mapping(address module => mapping(address authority => bytes32 attestationId)) internal
+        _moduleToAuthorityToAttestations;
 
     // Instance of Hashi's Yaho contract.
     Yaho public yaho;
@@ -53,10 +54,7 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
     error InsufficientValue();
     error InvalidAttestation();
     error InvalidAttestationRefUID(bytes32 missingRefUID);
-    error IncompatibleAttestation(
-        bytes32 sourceCodeHash,
-        bytes32 targetCodeHash
-    );
+    error IncompatibleAttestation(bytes32 sourceCodeHash, bytes32 targetCodeHash);
     error InvalidPropagation();
     error InvalidAttestations();
     error InvalidExpirationTime();
@@ -77,29 +75,28 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         address _l1Registry,
         string memory name,
         string memory version
-    ) EIP712Verifier(name, version) {
+    )
+        EIP712Verifier(name, version)
+    {
         yaho = _yaho;
         yaru = _yaru;
         l1Registry = _l1Registry;
     }
 
-    function attest(
-        AttestationRequest calldata request
-    ) external payable returns (bytes32) {
+    function attest(AttestationRequest calldata request) external payable returns (bytes32) {
         AttestationRequestData[] memory requests = new AttestationRequestData[](
             1
         );
         requests[0] = request.data;
 
-        return
-            _attest(request.schema, requests, msg.sender, msg.value, true).uids[
-                0
-            ];
+        return _attest(request.schema, requests, msg.sender, msg.value, true).uids[0];
     }
 
-    function multiAttest(
-        MultiAttestationRequest[] calldata multiRequests
-    ) external payable returns (bytes32[] memory) {
+    function multiAttest(MultiAttestationRequest[] calldata multiRequests)
+        external
+        payable
+        returns (bytes32[] memory)
+    {
         uint256 length = multiRequests.length;
         // Since a multi-attest call is going to make multiple attestations for multiple schemas, we'd need to collect
         // all the returned UIDs into a single list.
@@ -116,13 +113,8 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
 
             // Process the current batch of attestations.
             MultiAttestationRequest calldata multiRequest = multiRequests[i];
-            AttestationsResult memory res = _attest(
-                multiRequest.schema,
-                multiRequest.data,
-                msg.sender,
-                availableValue,
-                last
-            );
+            AttestationsResult memory res =
+                _attest(multiRequest.schema, multiRequest.data, msg.sender, availableValue, last);
 
             // Ensure to deduct the ETH that was forwarded to the resolver during the processing of this batch.
             availableValue -= res.usedValue;
@@ -141,30 +133,28 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
     /**
      * @inheritdoc IAttestation
      */
-    function attest(
-        DelegatedAttestationRequest calldata delegatedRequest
-    ) external payable returns (bytes32 attestationId) {
+    function attest(DelegatedAttestationRequest calldata delegatedRequest)
+        external
+        payable
+        returns (bytes32 attestationId)
+    {
         _verifyAttest(delegatedRequest);
 
         AttestationRequestData[] memory data = new AttestationRequestData[](1);
         data[0] = delegatedRequest.data;
 
-        return
-            _attest(
-                delegatedRequest.schema,
-                data,
-                delegatedRequest.attester,
-                msg.value,
-                true
-            ).uids[0];
+        return _attest(delegatedRequest.schema, data, delegatedRequest.attester, msg.value, true)
+            .uids[0];
     }
 
     /**
      * @inheritdoc IAttestation
      */
-    function multiAttest(
-        MultiDelegatedAttestationRequest[] calldata multiDelegatedRequests
-    ) external payable returns (bytes32[] memory attestationIds) {
+    function multiAttest(MultiDelegatedAttestationRequest[] calldata multiDelegatedRequests)
+        external
+        payable
+        returns (bytes32[] memory attestationIds)
+    {
         uint256 length = multiDelegatedRequests.length;
 
         // Since a multi-attest call is going to make multiple attestations for multiple schemas, we'd need to collect
@@ -187,16 +177,13 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
                 last = i == length - 1;
             }
 
-            MultiDelegatedAttestationRequest
-                calldata multiDelegatedRequest = multiDelegatedRequests[i];
+            MultiDelegatedAttestationRequest calldata multiDelegatedRequest =
+                multiDelegatedRequests[i];
             AttestationRequestData[] calldata data = multiDelegatedRequest.data;
             uint256 dataLength = data.length;
 
             // Ensure that no inputs are missing.
-            if (
-                dataLength == 0 ||
-                dataLength != multiDelegatedRequest.signatures.length
-            ) {
+            if (dataLength == 0 || dataLength != multiDelegatedRequest.signatures.length) {
                 revert InvalidLength();
             }
 
@@ -252,9 +239,7 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         messageIds = new bytes32[](length);
 
         for (uint256 i; i < length; i = uncheckedInc(i)) {
-            AttestationRecord memory attestationRecord = _attestations[
-                attestationIds[i]
-            ];
+            AttestationRecord memory attestationRecord = _attestations[attestationIds[i]];
             _resolvePropagation(attestationRecord, to, toChainId, moduleOnL2);
             if (attestationRecord.uid == EMPTY_UID) {
                 revert InvalidAttestation();
@@ -267,11 +252,7 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
                 moduleOnL2
             );
             // Prepare the message for dispatch.
-            messages[i] = Message({
-                to: to,
-                toChainId: toChainId,
-                data: callData
-            });
+            messages[i] = Message({ to: to, toChainId: toChainId, data: callData });
         }
         messageIds = yaho.dispatchMessages(messages);
     }
@@ -284,11 +265,12 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         uint256 toChainId,
         bytes32 attestationId,
         address moduleOnL2
-    ) public returns (Message[] memory messages, bytes32[] memory messageIds) {
+    )
+        public
+        returns (Message[] memory messages, bytes32[] memory messageIds)
+    {
         // Get the attestation record for the contract and the authority.
-        AttestationRecord memory attestationRecord = _attestations[
-            attestationId
-        ];
+        AttestationRecord memory attestationRecord = _attestations[attestationId];
         bytes32 codeHash = attestationRecord.subject.codeHash();
 
         _resolvePropagation(attestationRecord, to, toChainId, moduleOnL2);
@@ -299,19 +281,12 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
 
         // Encode the attestation record into a data payload.
         bytes memory callReceiveFnOnL2 = abi.encodeWithSelector(
-            this.attestByPropagation.selector,
-            attestationRecord,
-            codeHash,
-            moduleOnL2
+            this.attestByPropagation.selector, attestationRecord, codeHash, moduleOnL2
         );
 
         // Prepare the message for dispatch.
         messages = new Message[](1);
-        messages[0] = Message({
-            to: to,
-            toChainId: toChainId,
-            data: callReceiveFnOnL2
-        });
+        messages[0] = Message({ to: to, toChainId: toChainId, data: callReceiveFnOnL2 });
 
         messageIds = new bytes32[](1);
         // Dispatch message to selected L2
@@ -325,7 +300,10 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         AttestationRecord calldata attestation,
         bytes32 codeHash,
         address moduleAddress
-    ) external onlyHashi {
+    )
+        external
+        onlyHashi
+    {
         // Check if the code hash from sending chain matches the hash of the module address
         // if codeHash does not match, the attestation is invalid
         if (codeHash != moduleAddress.codeHash()) {
@@ -346,24 +324,18 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         }
 
         // check if attestationId already exists on this L2 registry
-        AttestationRecord storage existingRecord = _attestations[
-            attestation.uid
-        ];
+        AttestationRecord storage existingRecord = _attestations[attestation.uid];
         if (existingRecord.revocationTime != 0) revert InvalidAttestation();
         // can not propagate attestations that were commited natively after the original attestation was created
         if (existingRecord.time > attestation.time) revert InvalidAttestation();
 
         // Store the attestation
         _attestations[attestation.uid] = attestation;
-        _moduleToAuthorityToAttestations[attestation.subject][
-            attestation.attester
-        ] = attestation.uid;
+        _moduleToAuthorityToAttestations[attestation.subject][attestation.attester] =
+            attestation.uid;
         // Emit an event for the attestation
         emit Attested(
-            attestation.subject,
-            attestation.attester,
-            attestation.uid,
-            attestation.schema
+            attestation.subject, attestation.attester, attestation.uid, attestation.schema
         );
     }
 
@@ -376,9 +348,7 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         _revoke(request.schema, requests, msg.sender, msg.value, true);
     }
 
-    function multiRevoke(
-        MultiRevocationRequest[] calldata multiRequests
-    ) external payable {
+    function multiRevoke(MultiRevocationRequest[] calldata multiRequests) external payable {
         // We are keeping track of the total available ETH amount that can be sent to resolvers and will keep deducting
         // from it to verify that there isn't any attempt to send too much ETH to resolvers. Please note that unless
         // some ETH was stuck in the contract by accident (which shouldn't happen in normal conditions), it won't be
@@ -397,22 +367,15 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
             MultiRevocationRequest calldata multiRequest = multiRequests[i];
 
             // Ensure to deduct the ETH that was forwarded to the resolver during the processing of this batch.
-            availableValue -= _revoke(
-                multiRequest.schema,
-                multiRequest.data,
-                msg.sender,
-                availableValue,
-                last
-            );
+            availableValue -=
+                _revoke(multiRequest.schema, multiRequest.data, msg.sender, availableValue, last);
         }
     }
 
     /**
      * @inheritdoc IAttestation
      */
-    function revoke(
-        DelegatedRevocationRequest calldata request
-    ) external payable {
+    function revoke(DelegatedRevocationRequest calldata request) external payable {
         _verifyRevoke(request);
 
         RevocationRequestData[] memory data = new RevocationRequestData[](1);
@@ -424,9 +387,10 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
     /**
      * @inheritdoc IAttestation
      */
-    function multiRevoke(
-        MultiDelegatedRevocationRequest[] calldata multiDelegatedRequests
-    ) external payable {
+    function multiRevoke(MultiDelegatedRevocationRequest[] calldata multiDelegatedRequests)
+        external
+        payable
+    {
         // We are keeping track of the total available ETH amount that can be sent to resolvers and will keep deducting
         // from it to verify that there isn't any attempt to send too much ETH to resolvers. Please note that unless
         // some ETH was stuck in the contract by accident (which shouldn't happen in normal conditions), it won't be
@@ -443,16 +407,12 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
                 last = i == length - 1;
             }
 
-            MultiDelegatedRevocationRequest
-                memory multiDelegatedRequest = multiDelegatedRequests[i];
+            MultiDelegatedRevocationRequest memory multiDelegatedRequest = multiDelegatedRequests[i];
             RevocationRequestData[] memory data = multiDelegatedRequest.data;
             uint256 dataLength = data.length;
 
             // Ensure that no inputs are missing.
-            if (
-                dataLength == 0 ||
-                dataLength != multiDelegatedRequest.signatures.length
-            ) {
+            if (dataLength == 0 || dataLength != multiDelegatedRequest.signatures.length) {
                 revert InvalidLength();
             }
 
@@ -496,7 +456,10 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         address attester,
         uint256 availableValue,
         bool last
-    ) private returns (AttestationsResult memory res) {
+    )
+        private
+        returns (AttestationsResult memory res)
+    {
         uint256 length = data.length;
 
         res.uids = new bytes32[](length);
@@ -519,10 +482,7 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
             AttestationRequestData memory request = data[i];
 
             // Ensure that either no expiration time was set or that it was set in the future.
-            if (
-                request.expirationTime != NO_EXPIRATION_TIME &&
-                request.expirationTime <= timeNow
-            ) {
+            if (request.expirationTime != NO_EXPIRATION_TIME && request.expirationTime <= timeNow) {
                 revert InvalidExpirationTime();
             }
 
@@ -578,14 +538,8 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
             emit Attested(request.subject, attester, uid, schemaUID);
         }
 
-        res.usedValue = _resolveAttestations(
-            schemaRecord,
-            attestations,
-            values,
-            false,
-            availableValue,
-            last
-        );
+        res.usedValue =
+            _resolveAttestations(schemaRecord, attestations, values, false, availableValue, last);
 
         return res;
     }
@@ -607,7 +561,10 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         address revoker,
         uint256 availableValue,
         bool last
-    ) private returns (uint256) {
+    )
+        private
+        returns (uint256)
+    {
         // Ensure that a non-existing schema ID wasn't passed by accident.
         SchemaRecord memory schemaRecord = getSchema(schema);
         if (schemaRecord.uid == EMPTY_UID) {
@@ -656,23 +613,10 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
             attestations[i] = attestation;
             values[i] = request.value;
 
-            emit Revoked(
-                attestation.subject,
-                revoker,
-                request.uid,
-                attestation.schema
-            );
+            emit Revoked(attestation.subject, revoker, request.uid, attestation.schema);
         }
 
-        return
-            _resolveAttestations(
-                schemaRecord,
-                attestations,
-                values,
-                true,
-                availableValue,
-                last
-            );
+        return _resolveAttestations(schemaRecord, attestations, values, true, availableValue, last);
     }
 
     /**
@@ -694,7 +638,10 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         bool isRevocation,
         uint256 availableValue,
         bool last
-    ) private returns (uint256) {
+    )
+        private
+        returns (uint256)
+    {
         ISchemaResolver resolver = schemaRecord.resolver;
         if (address(resolver) == address(0)) {
             // Ensure that we don't accept payments if there is no resolver.
@@ -721,10 +668,10 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         }
 
         if (isRevocation) {
-            if (!resolver.revoke{value: value}(attestation)) {
+            if (!resolver.revoke{ value: value }(attestation)) {
                 revert InvalidRevocation();
             }
-        } else if (!resolver.attest{value: value}(attestation)) {
+        } else if (!resolver.attest{ value: value }(attestation)) {
             revert InvalidAttestation();
         }
 
@@ -754,18 +701,15 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         bool isRevocation,
         uint256 availableValue,
         bool last
-    ) private returns (uint256) {
+    )
+        private
+        returns (uint256)
+    {
         uint256 length = attestations.length;
         if (length == 1) {
-            return
-                _resolveAttestation(
-                    schemaRecord,
-                    attestations[0],
-                    values[0],
-                    isRevocation,
-                    availableValue,
-                    last
-                );
+            return _resolveAttestation(
+                schemaRecord, attestations[0], values[0], isRevocation, availableValue, last
+            );
         }
 
         ISchemaResolver resolver = schemaRecord.resolver;
@@ -803,17 +747,10 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         }
 
         if (isRevocation) {
-            if (
-                !resolver.multiRevoke{value: totalUsedValue}(
-                    attestations,
-                    values
-                )
-            ) {
+            if (!resolver.multiRevoke{ value: totalUsedValue }(attestations, values)) {
                 revert InvalidRevocations();
             }
-        } else if (
-            !resolver.multiAttest{value: totalUsedValue}(attestations, values)
-        ) {
+        } else if (!resolver.multiAttest{ value: totalUsedValue }(attestations, values)) {
             revert InvalidAttestations();
         }
 
@@ -824,9 +761,7 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         return totalUsedValue;
     }
 
-    function _newUID(
-        AttestationRecord memory attestation
-    ) private view returns (bytes32 uid) {
+    function _newUID(AttestationRecord memory attestation) private view returns (bytes32 uid) {
         uint256 bump;
         while (true) {
             uid = _getUID(attestation, bump);
@@ -847,7 +782,11 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         bytes32 schema,
         address attester,
         AttestationRequestData memory request
-    ) external view returns (bytes32 uid) {
+    )
+        external
+        view
+        returns (bytes32 uid)
+    {
         AttestationRecord memory attestation = AttestationRecord({
             uid: EMPTY_UID,
             schema: schema,
@@ -875,21 +814,24 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
     function _getUID(
         AttestationRecord memory attestation,
         uint256 bump
-    ) private pure returns (bytes32) {
-        return
-            keccak256(
-                abi.encodePacked(
-                    attestation.schema,
-                    attestation.subject,
-                    attestation.attester,
-                    // attestation.time, <-- makes UIDs unpredictable. is removing this a security issue?
-                    attestation.expirationTime,
-                    attestation.revocable,
-                    attestation.refUID,
-                    attestation.data,
-                    bump
-                )
-            );
+    )
+        private
+        pure
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encodePacked(
+                attestation.schema,
+                attestation.subject,
+                attestation.attester,
+                // attestation.time, <-- makes UIDs unpredictable. is removing this a security issue?
+                attestation.expirationTime,
+                attestation.revocable,
+                attestation.refUID,
+                attestation.data,
+                bump
+            )
+        );
     }
 
     /**
@@ -901,9 +843,7 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
      *
      * @return array2 The converted array of uint256
      */
-    function _toUint256Array(
-        bytes32[] memory array
-    ) internal pure returns (uint256[] memory) {
+    function _toUint256Array(bytes32[] memory array) internal pure returns (uint256[] memory) {
         uint256 length = array.length;
         uint256[] memory array2 = new uint256[](length);
         for (uint256 i; i < length; ++i) {
@@ -945,7 +885,11 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
     function _mergeUIDs(
         bytes32[][] memory uidLists,
         uint256 uidsCount
-    ) private pure returns (bytes32[] memory) {
+    )
+        private
+        pure
+        returns (bytes32[] memory)
+    {
         bytes32[] memory uids = new bytes32[](uidsCount);
 
         uint256 currentIndex = 0;
@@ -985,16 +929,13 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         address to,
         uint256 toChainId,
         address moduleOnL2
-    ) private returns (bool) {
+    )
+        private
+        returns (bool)
+    {
         ISchemaResolver resolver = getSchema(attestation.schema).resolver;
         if (address(resolver) != address(0)) {
-            bool valid = resolver.propagation(
-                attestation,
-                msg.sender,
-                to,
-                toChainId,
-                moduleOnL2
-            );
+            bool valid = resolver.propagation(attestation, msg.sender, to, toChainId, moduleOnL2);
             if (valid) return valid;
             else revert InvalidPropagation();
         }
@@ -1007,22 +948,25 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
         }
     }
 
-    function getSchema(
-        bytes32 uid
-    ) public view virtual returns (SchemaRecord memory);
+    function getSchema(bytes32 uid) public view virtual returns (SchemaRecord memory);
 
-    function getBridges(
-        bytes32 uid
-    ) public view virtual returns (address[] memory);
+    function getBridges(bytes32 uid) public view virtual returns (address[] memory);
 
-    function _getModule(
-        address moduleAddress
-    ) internal view virtual returns (ModuleRecord storage);
+    function _getModule(address moduleAddress)
+        internal
+        view
+        virtual
+        returns (ModuleRecord storage);
 
     function _getAttestation(
         address module,
         address authority
-    ) internal view virtual returns (bytes32) {
+    )
+        internal
+        view
+        virtual
+        returns (bytes32)
+    {
         return _moduleToAuthorityToAttestations[module][authority];
     }
 }

--- a/src/base/Attestation.sol
+++ b/src/base/Attestation.sol
@@ -491,14 +491,19 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
                 revert Irrevocable();
             }
 
-            // Ensure that attestation is for module that was registered.
-            if (_getModule(request.subject).implementation == address(0)) {
-                revert InvalidAttestation();
-            }
+            // Block scope to avoid stack too deep
+            {
+                ModuleRecord memory moduleRecord = _getModule(request.subject);
 
-            // Ensure that attestation for a module is using the modules schemaId
-            if (_getModule(request.subject).schemaUID != schemaUID) {
-                revert InvalidAttestation();
+                // Ensure that attestation is for module that was registered.
+                if (moduleRecord.implementation == address(0)) {
+                    revert InvalidAttestation();
+                }
+
+                // Ensure that attestation for a module is using the modules schemaId
+                if (moduleRecord.schemaUID != schemaUID) {
+                    revert InvalidAttestation();
+                }
             }
 
             AttestationRecord memory attestation = AttestationRecord({

--- a/src/base/Attestation.sol
+++ b/src/base/Attestation.sol
@@ -840,24 +840,6 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
     }
 
     /**
-     * @notice Converts an array of bytes32 to an array of uint256
-     *
-     * @dev Iterates over the input array and converts each bytes32 to uint256
-     *
-     * @param array The array of bytes32 to convert
-     *
-     * @return array2 The converted array of uint256
-     */
-    function _toUint256Array(bytes32[] memory array) internal pure returns (uint256[] memory) {
-        uint256 length = array.length;
-        uint256[] memory array2 = new uint256[](length);
-        for (uint256 i; i < length; ++i) {
-            array2[i] = uint256(array[i]);
-        }
-        return array2;
-    }
-
-    /**
      * @dev Refunds remaining ETH amount to the attester.
      *
      * @param remainingValue The remaining ETH amount that was not sent to the resolver.
@@ -943,13 +925,6 @@ abstract contract Attestation is IAttestation, EIP712Verifier {
             bool valid = resolver.propagation(attestation, msg.sender, to, toChainId, moduleOnL2);
             if (valid) return valid;
             else revert InvalidPropagation();
-        }
-    }
-
-    function _enforceOnlySchemaOwner(bytes32 schemaUID) internal view {
-        address schemaOwner = getSchema(schemaUID).schemaOwner;
-        if (schemaOwner != msg.sender) {
-            revert AccessDenied();
         }
     }
 

--- a/src/base/Module.sol
+++ b/src/base/Module.sol
@@ -50,14 +50,14 @@ abstract contract Module is IModule {
         bytes calldata deployParams,
         uint256 salt,
         bytes calldata data,
-        bytes32 schemaId
+        bytes32 schemaUID
     )
         external
         returns (address moduleAddr)
     {
-        // Check if the provided schemaId exists
-        SchemaRecord memory schema = getSchema(schemaId);
-        if (schemaId != schema.uid) revert InvalidSchema();
+        // Check if the provided schemaUID exists
+        SchemaRecord memory schema = getSchema(schemaUID);
+        if (schemaUID != schema.uid) revert InvalidSchema();
 
         bytes32 contractCodeHash; //  Hash of contract bytecode
         bytes32 deployParamsHash; // Hash of contract deployment parameters
@@ -71,10 +71,10 @@ abstract contract Module is IModule {
     // this function might be removed in the future.
     // could be a security risk
     // TODO
-    function register(bytes32 schemaId, address moduleAddress, bytes calldata data) external {
-        // Check if the provided schemaId exists
-        SchemaRecord memory schema = getSchema(schemaId);
-        if (schemaId != schema.uid) revert InvalidSchema();
+    function register(bytes32 schemaUID, address moduleAddress, bytes calldata data) external {
+        // Check if the provided schemaUID exists
+        SchemaRecord memory schema = getSchema(schemaUID);
+        if (schemaUID != schema.uid) revert InvalidSchema();
 
         // get codehash of depoyed contract
         bytes32 contractCodeHash = moduleAddress.codeHash();
@@ -85,7 +85,7 @@ abstract contract Module is IModule {
 
     function _register(
         address moduleAddress,
-        address sender,
+        address deployer,
         SchemaRecord memory schema,
         bytes32 codeHash,
         bytes32 deployParamsHash,
@@ -102,8 +102,8 @@ abstract contract Module is IModule {
             implementation: moduleAddress,
             codeHash: codeHash,
             deployParamsHash: deployParamsHash,
-            schemaId: schema.uid,
-            sender: sender,
+            schemaUID: schema.uid,
+            deployer: deployer,
             data: data
         });
 
@@ -119,10 +119,12 @@ abstract contract Module is IModule {
         private
     {
         if (address(resolver) == address(0)) return;
-        if (resolver.moduleRegistration(moduleRegistration) == false) revert InvalidDeployment();
+        if (resolver.moduleRegistration(moduleRegistration) == false) {
+            revert InvalidDeployment();
+        }
     }
 
-    function getSchema(bytes32 uid) public view virtual returns (SchemaRecord memory);
+    function getSchema(bytes32 schemaUID) public view virtual returns (SchemaRecord memory);
 
     function _getModule(address moduleAddress)
         internal

--- a/src/base/Module.sol
+++ b/src/base/Module.sol
@@ -12,13 +12,9 @@ import { AttestationRecord, ModuleRecord } from "../Common.sol";
 /**
  * @title Module
  *
- * @dev The Module contract serves as a component in a larger system for handling smart contracts or "modules"
- * within a blockchain ecosystem. This contract inherits from the IModule interface and the Schema contract,
- * providing the actual implementation for the interface and extending the functionality of the Schema contract.
- *
- * @dev The primary responsibility of the Module is to deploy and manage modules. A module is a smart contract
- * that has been deployed through the Module. The details of each module, such as its address, code hash, schema ID,
- * sender address, deploy parameters hash, and additional data are stored in a struct and mapped to the module's address in
+ * @dev The primary responsibility of the Module contract is to deploy and manage modules. A module is a smart contract
+ * that extends the functionality of a smart account. The details of each module, such as its address, code hash, schema ID,
+ * deployer address, deploy parameters hash, and additional data are stored in a struct and mapped to the module's address in
  * the `_modules` mapping for easy access and management.
  *
  * @dev The `deploy` function is used to deploy a new module. The code of the module, parameters for deployment (constructor arguments),
@@ -26,13 +22,9 @@ import { AttestationRecord, ModuleRecord } from "../Common.sol";
  * all passed as arguments to this function. This function first checks if the provided schema ID is valid and then deploys the contract.
  * Once the contract is successfully deployed, the details are stored in the `_modules` mapping and a `Deployment` event is emitted.
  *
- * @dev Furthermore, the Module contract utilizes the Ethereum `CREATE2` opcode in its `_deploy` function for deploying
- * contracts. This opcode allows creating a contract with a deterministic address, which is calculated in the `_calcAddress` function.
- * This approach provides flexibility and advanced patterns in contract interactions, like the ability to show a contract’s address
- * before it is mined.
- *
- * @dev In conclusion, the Module is a central part of a system to manage, deploy, and interact with a set of smart contracts
- * in a structured and controlled manner.
+ * @dev Furthermore, the Module contract utilizes the `CREATE2` opcode in its `_deploy` function for deploying contracts. This opcode
+ * allows creating a contract with a deterministic address, which is calculated in the `_calcAddress` function. This approach provides
+ * flexibility and advanced patterns in contract interactions, like the ability to show a contract’s address before it is mined.
  */
 abstract contract Module is IModule {
     mapping(address moduleAddress => ModuleRecord) internal _modules;

--- a/src/base/Schema.sol
+++ b/src/base/Schema.sol
@@ -12,9 +12,9 @@ import { ISchemaResolver } from "../resolver/ISchemaResolver.sol";
  *
  * @author zeroknots.eth
  *
- * @dev The Schema contract serves as a crucial component of a broader system for managing "schemas" within a
- * blockchain ecosystem. It provides functionality to register, retrieve and manage schemas. This contract is a
- * concrete implementation of the ISchema interface.
+ * @dev The Schema contract serves as a crucial component that allows the registry to be maximally flexible.
+ * It provides functionality to register, retrieve and manage schemas. This contract is a concrete implementation of
+ * the ISchema interface.
  *
  * @dev A schema in this context is a defined structure that represents a record for a submitted schema,
  * encompassing its unique identifier (UID), resolver (optional), revocability status, specification, owner's address,
@@ -30,9 +30,6 @@ import { ISchemaResolver } from "../resolver/ISchemaResolver.sol";
  *
  * @dev Furthermore, the Schema contract introduces access control by ensuring that certain operations such as setting
  * bridges and resolvers can only be performed by the owner of the schema.
- *
- * @dev In summary, the Schema contract is an integral part of a larger system, providing the functionality to register,
- * retrieve, and manage schemas in a controlled and structured manner.
  */
 abstract contract Schema is ISchema {
     // The version of the contract.

--- a/src/eip712/EIP712Verifier.sol
+++ b/src/eip712/EIP712Verifier.sol
@@ -92,19 +92,19 @@ abstract contract EIP712Verifier is EIP712 {
 
     function getAttestationDigest(
         AttestationRequestData memory attData,
-        bytes32 schemaUid,
+        bytes32 schemaUID,
         uint256 nonce
     )
         public
         view
         returns (bytes32 digest)
     {
-        digest = _attestationDigest(attData, schemaUid, nonce);
+        digest = _attestationDigest(attData, schemaUID, nonce);
     }
 
     function getAttestationDigest(
         AttestationRequestData memory attData,
-        bytes32 schemaUid,
+        bytes32 schemaUID,
         address attester
     )
         public
@@ -112,12 +112,12 @@ abstract contract EIP712Verifier is EIP712 {
         returns (bytes32 digest)
     {
         uint256 nonce = getNonce(attester) + 1;
-        digest = _attestationDigest(attData, schemaUid, nonce);
+        digest = _attestationDigest(attData, schemaUID, nonce);
     }
 
     function _attestationDigest(
         AttestationRequestData memory data,
-        bytes32 schemaUid,
+        bytes32 schemaUID,
         uint256 nonce
     )
         private
@@ -128,7 +128,7 @@ abstract contract EIP712Verifier is EIP712 {
             keccak256(
                 abi.encode(
                     ATTEST_TYPEHASH,
-                    schemaUid,
+                    schemaUID,
                     data.subject,
                     data.expirationTime,
                     data.revocable,
@@ -149,7 +149,7 @@ abstract contract EIP712Verifier is EIP712 {
         AttestationRequestData memory data = request.data;
 
         uint256 nonce = _newNonce(request.attester);
-        bytes32 digest = _attestationDigest(data, request.schema, nonce);
+        bytes32 digest = _attestationDigest(data, request.schemaUID, nonce);
         _verifySignature(digest, request.signature, request.attester);
     }
 
@@ -161,7 +161,7 @@ abstract contract EIP712Verifier is EIP712 {
 
     function getRevocationDigest(
         RevocationRequestData memory revData,
-        bytes32 schemaUid,
+        bytes32 schemaUID,
         address revoker
     )
         public
@@ -169,11 +169,11 @@ abstract contract EIP712Verifier is EIP712 {
         returns (bytes32 digest)
     {
         uint256 nonce = getNonce(revoker) + 1;
-        digest = _revocationDigest(schemaUid, revData.uid, nonce);
+        digest = _revocationDigest(schemaUID, revData.uid, nonce);
     }
 
     function _revocationDigest(
-        bytes32 schemaUid,
+        bytes32 schemaUID,
         bytes32 revocationId,
         uint256 nonce
     )
@@ -182,7 +182,7 @@ abstract contract EIP712Verifier is EIP712 {
         returns (bytes32 digest)
     {
         digest =
-            _hashTypedDataV4(keccak256(abi.encode(REVOKE_TYPEHASH, schemaUid, revocationId, nonce)));
+            _hashTypedDataV4(keccak256(abi.encode(REVOKE_TYPEHASH, schemaUID, revocationId, nonce)));
     }
 
     /**
@@ -194,7 +194,7 @@ abstract contract EIP712Verifier is EIP712 {
         RevocationRequestData memory data = request.data;
 
         uint256 nonce = _newNonce(request.revoker);
-        bytes32 digest = _revocationDigest(request.schema, data.uid, nonce);
+        bytes32 digest = _revocationDigest(request.schemaUID, data.uid, nonce);
         _verifySignature(digest, request.signature, request.revoker);
     }
 

--- a/src/interface/IAttestation.sol
+++ b/src/interface/IAttestation.sol
@@ -28,7 +28,7 @@ struct AttestationRequestData {
  * @dev A struct representing the full arguments of the attestation request.
  */
 struct AttestationRequest {
-    bytes32 schema; // The unique identifier of the schema.
+    bytes32 schemaUID; // The unique identifier of the schema.
     AttestationRequestData data; // The arguments of the attestation request.
 }
 
@@ -36,7 +36,7 @@ struct AttestationRequest {
  * @dev A struct representing the full arguments of the full delegated attestation request.
  */
 struct DelegatedAttestationRequest {
-    bytes32 schema; // The unique identifier of the schema.
+    bytes32 schemaUID; // The unique identifier of the schema.
     AttestationRequestData data; // The arguments of the attestation request.
     bytes signature; // The EIP712 signature data.
     address attester; // The attesting account.
@@ -46,7 +46,7 @@ struct DelegatedAttestationRequest {
  * @dev A struct representing the full arguments of the multi attestation request.
  */
 struct MultiAttestationRequest {
-    bytes32 schema; // The unique identifier of the schema.
+    bytes32 schemaUID; // The unique identifier of the schema.
     AttestationRequestData[] data; // The arguments of the attestation request.
 }
 
@@ -54,7 +54,7 @@ struct MultiAttestationRequest {
  * @dev A struct representing the full arguments of the delegated multi attestation request.
  */
 struct MultiDelegatedAttestationRequest {
-    bytes32 schema; // The unique identifier of the schema.
+    bytes32 schemaUID; // The unique identifier of the schema.
     AttestationRequestData[] data; // The arguments of the attestation requests.
     bytes[] signatures; // The EIP712 signatures data. Please note that the signatures are assumed to be signed with increasing nonces.
     address attester; // The attesting account.
@@ -72,7 +72,7 @@ struct RevocationRequestData {
  * @dev A struct representing the full arguments of the revocation request.
  */
 struct RevocationRequest {
-    bytes32 schema; // The unique identifier of the schema.
+    bytes32 schemaUID; // The unique identifier of the schema.
     RevocationRequestData data; // The arguments of the revocation request.
 }
 
@@ -80,7 +80,7 @@ struct RevocationRequest {
  * @dev A struct representing the arguments of the full delegated revocation request.
  */
 struct DelegatedRevocationRequest {
-    bytes32 schema; // The unique identifier of the schema.
+    bytes32 schemaUID; // The unique identifier of the schema.
     RevocationRequestData data; // The arguments of the revocation request.
     bytes signature; // The EIP712 signature data.
     address revoker; // The revoking account.
@@ -90,7 +90,7 @@ struct DelegatedRevocationRequest {
  * @dev A struct representing the full arguments of the multi revocation request.
  */
 struct MultiRevocationRequest {
-    bytes32 schema; // The unique identifier of the schema.
+    bytes32 schemaUID; // The unique identifier of the schema.
     RevocationRequestData[] data; // The arguments of the revocation request.
 }
 
@@ -98,7 +98,7 @@ struct MultiRevocationRequest {
  * @dev A struct representing the full arguments of the delegated multi revocation request.
  */
 struct MultiDelegatedRevocationRequest {
-    bytes32 schema; // The unique identifier of the schema.
+    bytes32 schemaUID; // The unique identifier of the schema.
     RevocationRequestData[] data; // The arguments of the revocation requests.
     bytes[] signatures; // The EIP712 signatures data. Please note that the signatures are assumed to be signed with increasing nonces.
     address revoker; // The revoking account.
@@ -111,10 +111,10 @@ interface IAttestation {
      * @param subject The subject of the attestation.
      * @param attester The attesting account.
      * @param uid The UID of the attestation.
-     * @param schema The UID of the schema.
+     * @param schemaUID The UID of the schema.
      */
     event Attested(
-        address indexed subject, address indexed attester, bytes32 uid, bytes32 indexed schema
+        address indexed subject, address indexed attester, bytes32 uid, bytes32 indexed schemaUID
     );
 
     /**
@@ -123,10 +123,10 @@ interface IAttestation {
      * @param subject The subject of the attestation.
      * @param attester The attesting account.
      * @param uid The UID the revoked attestation.
-     * @param schema The UID of the schema.
+     * @param schemaUID The UID of the schema.
      */
     event Revoked(
-        address indexed subject, address indexed attester, bytes32 uid, bytes32 indexed schema
+        address indexed subject, address indexed attester, bytes32 uid, bytes32 indexed schemaUID
     );
 
     /**
@@ -256,12 +256,12 @@ interface IAttestation {
      *
      * @dev The function returns the UID of the attestation that would be issued for the given request
      *
-     * @param schema The schema of the attestation
+     * @param schemaUID The schema of the attestation
      * @param attester The attester of the attestation
      * @param request The request data
      */
     function predictAttestationUID(
-        bytes32 schema,
+        bytes32 schemaUID,
         address attester,
         AttestationRequestData memory request
     )

--- a/test/Attestation.t.sol
+++ b/test/Attestation.t.sol
@@ -102,7 +102,7 @@ contract AttestationTest is BaseTest {
         EIP712Signature memory sig = EIP712Signature({ v: 27, r: "", s: "" });
 
         DelegatedAttestationRequest memory req = DelegatedAttestationRequest({
-            schema: defaultSchema1,
+            schemaUID: defaultSchema1,
             data: attData,
             signature: abi.encode(sig),
             attester: address(attester)
@@ -136,7 +136,9 @@ contract AttestationTest is BaseTest {
             value: 0
         });
 
-        AttestationRequestData[] memory attArray = new AttestationRequestData[](2);
+        AttestationRequestData[] memory attArray = new AttestationRequestData[](
+            2
+        );
         attArray[0] = attData1;
         attArray[1] = attData2;
 
@@ -149,7 +151,7 @@ contract AttestationTest is BaseTest {
 
         MultiDelegatedAttestationRequest[] memory reqs = new MultiDelegatedAttestationRequest[](1);
         MultiDelegatedAttestationRequest memory req1 = MultiDelegatedAttestationRequest({
-            schema: defaultSchema1,
+            schemaUID: defaultSchema1,
             data: attArray,
             attester: vm.addr(auth1k),
             signatures: sigsBytes

--- a/test/AttestationPropagationL2.t.sol
+++ b/test/AttestationPropagationL2.t.sol
@@ -20,22 +20,22 @@ contract AttestationPropagationL2Test is AttestationTest {
     }
 
     function testPropagateWithHashi() public {
-        bytes32 schemaId =
+        bytes32 schemaUID =
             instancel1.registerSchema("Propagation Test", ISchemaResolver(address(0)), true);
-        bytes32 schemaId2 =
+        bytes32 schemaUID2 =
             instancel2.registerSchema("Propagation Test", ISchemaResolver(address(0)), true);
 
-        assertEq(schemaId, schemaId2);
+        assertEq(schemaUID, schemaUID2);
 
         bytes memory bytecode = type(MockModuleWithArgs).creationCode;
         address moduleAddr = instancel1.deployAndRegister({
-            schemaId: schemaId,
+            schemaUID: schemaUID,
             bytecode: bytecode,
             constructorArgs: abi.encode(313_131_123)
         });
-        attestationUid1 = instancel1.mockAttestation(schemaId, auth1k, moduleAddr);
+        attestationUid1 = instancel1.mockAttestation(schemaUID, auth1k, moduleAddr);
 
-        instancel2.registry.register({ schemaId: schemaId2, moduleAddress: moduleAddr, data: "" });
+        instancel2.registry.register({ schemaUID: schemaUID2, moduleAddress: moduleAddr, data: "" });
         (Message[] memory messages, bytes32[] memory messageIdsBytes32) = instancel1
             .registry
             .propagateAttest({
@@ -63,25 +63,25 @@ contract AttestationPropagationL2Test is AttestationTest {
     }
 
     function testPropagateMultipleAttestations() public {
-        bytes32 schemaId =
+        bytes32 schemaUID =
             instancel1.registerSchema("Propagation Test", ISchemaResolver(address(0)), true);
-        bytes32 schemaId2 =
+        bytes32 schemaUID2 =
             instancel2.registerSchema("Propagation Test", ISchemaResolver(address(0)), true);
 
-        assertEq(schemaId, schemaId2);
+        assertEq(schemaUID, schemaUID2);
 
         bytes memory bytecode = type(MockModuleWithArgs).creationCode;
         address moduleAddr = instancel1.deployAndRegister({
-            schemaId: schemaId,
+            schemaUID: schemaUID,
             bytecode: bytecode,
             constructorArgs: abi.encode(313_131_123)
         });
-        attestationUid1 = instancel1.mockAttestation(schemaId, auth1k, moduleAddr);
-        bytes32 attestation2 = instancel1.mockAttestation(schemaId, 1, moduleAddr);
-        bytes32 attestation3 = instancel1.mockAttestation(schemaId, 2, moduleAddr);
-        bytes32 attestation4 = instancel1.mockAttestation(schemaId, 3, moduleAddr);
+        attestationUid1 = instancel1.mockAttestation(schemaUID, auth1k, moduleAddr);
+        bytes32 attestation2 = instancel1.mockAttestation(schemaUID, 1, moduleAddr);
+        bytes32 attestation3 = instancel1.mockAttestation(schemaUID, 2, moduleAddr);
+        bytes32 attestation4 = instancel1.mockAttestation(schemaUID, 3, moduleAddr);
 
-        instancel2.registry.register({ schemaId: schemaId2, moduleAddress: moduleAddr, data: "" });
+        instancel2.registry.register({ schemaUID: schemaUID2, moduleAddress: moduleAddr, data: "" });
 
         bytes32[] memory attestationIds = new bytes32[](4);
         attestationIds[0] = attestationUid1;

--- a/test/ModuleRegistry.t.sol
+++ b/test/ModuleRegistry.t.sol
@@ -15,23 +15,23 @@ contract ModuleTest is BaseTest {
         super.setUp();
     }
 
-    function testDeployWithArgs() public returns (bytes32 schemaId, address moduleAddr) {
-        schemaId = instancel1.registerSchema("Test ABI 123", ISchemaResolver(address(0)), true);
+    function testDeployWithArgs() public returns (bytes32 schemaUID, address moduleAddr) {
+        schemaUID = instancel1.registerSchema("Test ABI 123", ISchemaResolver(address(0)), true);
 
         bytes memory bytecode = type(MockModuleWithArgs).creationCode;
         moduleAddr = instancel1.deployAndRegister({
-            schemaId: schemaId,
+            schemaUID: schemaUID,
             bytecode: bytecode,
             constructorArgs: abi.encode(313_131)
         });
     }
 
-    function testDeployNoArgs() public returns (bytes32 schemaId, address moduleAddr) {
-        schemaId = instancel1.registerSchema("Test ABI 123", ISchemaResolver(address(0)), true);
+    function testDeployNoArgs() public returns (bytes32 schemaUID, address moduleAddr) {
+        schemaUID = instancel1.registerSchema("Test ABI 123", ISchemaResolver(address(0)), true);
 
         bytes memory bytecode = type(MockModule).creationCode;
         moduleAddr = instancel1.deployAndRegister({
-            schemaId: schemaId,
+            schemaUID: schemaUID,
             bytecode: bytecode,
             constructorArgs: bytes("")
         });
@@ -39,25 +39,25 @@ contract ModuleTest is BaseTest {
 
     function testNonexistingModule() public {
         // TODO
-        bytes32 schemaId =
+        bytes32 schemaUID =
             instancel1.registerSchema("Test ABI 123", ISchemaResolver(address(0)), true);
 
         address module = makeAddr("doesntExist");
         vm.expectRevert();
-        instancel1.registry.register(schemaId, module, "");
+        instancel1.registry.register(schemaUID, module, "");
     }
 
     function testReRegisterModule() public {
-        bytes32 schemaId =
+        bytes32 schemaUID =
             instancel1.registerSchema("Test ABI 123", ISchemaResolver(address(0)), true);
 
         bytes memory bytecode = type(MockModule).creationCode;
         address moduleAddr = instancel1.deployAndRegister({
-            schemaId: schemaId,
+            schemaUID: schemaUID,
             bytecode: bytecode,
             constructorArgs: abi.encode(313_132)
         });
         vm.expectRevert(abi.encodeWithSelector(Module.AlreadyRegistered.selector, moduleAddr));
-        instancel1.registry.register(schemaId, moduleAddr, "");
+        instancel1.registry.register(schemaUID, moduleAddr, "");
     }
 }

--- a/test/resolvers/ValueResolver.t.sol
+++ b/test/resolvers/ValueResolver.t.sol
@@ -15,11 +15,11 @@ contract ValueResolverTest is BaseTest {
     }
 
     function testValueResolver() public {
-        bytes32 schema =
+        bytes32 schemaUID =
             instancel1.registerSchema("TokenizedResolver", ISchemaResolver(address(resolver)), true);
 
         address module = instancel1.deployAndRegister(
-            schema, type(MockModuleWithArgs).creationCode, abi.encode("asdfasdf")
+            schemaUID, type(MockModuleWithArgs).creationCode, abi.encode("asdfasdf")
         );
 
         AttestationRequestData memory attData = AttestationRequestData({
@@ -33,9 +33,9 @@ contract ValueResolverTest is BaseTest {
         });
 
         EIP712Signature memory signature =
-            RegistryTestLib.signAttestation(instancel1, schema, auth1k, attData);
+            RegistryTestLib.signAttestation(instancel1, schemaUID, auth1k, attData);
         DelegatedAttestationRequest memory req = DelegatedAttestationRequest({
-            schema: schema,
+            schemaUID: schemaUID,
             data: attData,
             signature: abi.encode(signature),
             attester: vm.addr(auth1k)

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -73,12 +73,12 @@ contract BaseTest is Test, RegistryTestTools {
         );
 
         instancel2.registry.register({
-            schemaId: defaultSchema2,
+            schemaUID: defaultSchema2,
             moduleAddress: defaultModule1,
             data: ""
         });
         instancel2.registry.register({
-            schemaId: defaultSchema2,
+            schemaUID: defaultSchema2,
             moduleAddress: defaultModule2,
             data: ""
         });


### PR DESCRIPTION
Changes:

- replace bytes32 schema/schemaId/schemaUid with schemaUID: [commit](https://github.com/rhinestonewtf/registry/commit/6ad57c16e69a25018cacd7b5207191c396df724e)
- replace sender of ModuleRecord with deployer: [commit](https://github.com/rhinestonewtf/registry/commit/6ad57c16e69a25018cacd7b5207191c396df724e)
- cache ModuleRecord to save gas: [commit](https://github.com/rhinestonewtf/registry/commit/b806ce59ce9a633a0e86ea983e5d767d04363472)
- remove dead code: [commit](https://github.com/rhinestonewtf/registry/commit/a5b53a7c0710fdfc9af87e581c30b126106489b1)
- clean up contract-level natspec: [commit](https://github.com/rhinestonewtf/registry/commit/18c9e6c4bcc3a427e31a8e4d02054558a3ef0898)
- update pfp link: [commit](https://github.com/rhinestonewtf/registry/commit/00a5b285d3cb4c825379e94d3bbd3aba3fe47452)