### PR TITLE
Chore/refactor functions

### DIFF
--- a/.t
+++ b/.t
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-nvim -c 'Telescope find_files'

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -37,7 +37,7 @@ contract Registry is Schema, Query, AttestationDelegation, Module {
         override(AttestationResolve, Schema)
         returns (SchemaRecord storage)
     {
-        return super._getSchema(uid);
+        return super._getSchema({ schemaUID: uid });
     }
 
     function _getAttestation(

--- a/src/base/Attestation.sol
+++ b/src/base/Attestation.sol
@@ -60,18 +60,27 @@ abstract contract Attestation is IAttestation, AttestationResolve, ReentrancyGua
     function attest(AttestationRequest calldata request) external payable nonReentrant {
         AttestationRequestData calldata requestData = request.data;
 
-        ModuleRecord storage moduleRecord = _getModule(request.data.subject);
+        ModuleRecord storage moduleRecord = _getModule({ moduleAddress: request.data.subject });
         ResolverUID resolverUID = moduleRecord.resolverUID;
 
-        AttestationRecord[] memory attestations = new AttestationRecord[](1);
-        uint256[] memory values = new uint256[](1);
-
         // write attestations to registry storge
-        (attestations[0], values[0]) =
-            _writeAttestation(request.schemaUID, resolverUID, requestData, msg.sender, _time());
+        (AttestationRecord memory attestation, uint256 value) = _writeAttestation({
+            schemaUID: request.schemaUID,
+            resolverUID: resolverUID,
+            request: requestData,
+            attester: msg.sender,
+            timeNow: _time()
+        });
 
         // trigger the resolver procedure
-        _resolveAttestations(resolverUID, attestations, values, false, msg.value, true);
+        _resolveAttestation({
+            resolverUID: resolverUID,
+            attestation: attestation,
+            value: value,
+            isRevocation: false,
+            availableValue: msg.value,
+            last: true
+        });
     }
 
     /**
@@ -86,7 +95,8 @@ abstract contract Attestation is IAttestation, AttestationResolve, ReentrancyGua
         uint256 availableValue = msg.value;
 
         // Batched Revocations can only be done for a single resolver. See IAttestation.sol
-        ModuleRecord storage moduleRecord = _getModule(multiRequests[0].data[0].subject);
+        ModuleRecord storage moduleRecord =
+            _getModule({ moduleAddress: multiRequests[0].data[0].subject });
 
         for (uint256 i; i < length; i = uncheckedInc(i)) {
             // The last batch is handled slightly differently: if the total available ETH wasn't spent in full and there
@@ -126,9 +136,19 @@ abstract contract Attestation is IAttestation, AttestationResolve, ReentrancyGua
         );
         requests[0] = request.data;
 
-        ModuleRecord memory moduleRecord = _getModule(request.data.subject);
+        ModuleRecord memory moduleRecord = _getModule({ moduleAddress: request.data.subject });
 
-        _revoke(request.schemaUID, moduleRecord.resolverUID, requests, msg.sender, msg.value, true);
+        AttestationRecord memory attestation =
+            _revoke({ schemaUID: request.schemaUID, request: request.data, revoker: msg.sender });
+
+        _resolveAttestation({
+            resolverUID: moduleRecord.resolverUID,
+            attestation: attestation,
+            value: 0,
+            isRevocation: true,
+            availableValue: msg.value,
+            last: true
+        });
     }
 
     /**
@@ -146,7 +166,8 @@ abstract contract Attestation is IAttestation, AttestationResolve, ReentrancyGua
         uint256 availableValue = msg.value;
 
         // Batched Revocations can only be done for a single resolver. See IAttestation.sol
-        ModuleRecord memory moduleRecord = _getModule(multiRequests[0].data[0].subject);
+        ModuleRecord memory moduleRecord =
+            _getModule({ moduleAddress: multiRequests[0].data[0].subject });
         uint256 requestsLength = multiRequests.length;
 
         // should cache length
@@ -162,14 +183,14 @@ abstract contract Attestation is IAttestation, AttestationResolve, ReentrancyGua
             MultiRevocationRequest calldata multiRequest = multiRequests[i];
 
             // Ensure to deduct the ETH that was forwarded to the resolver during the processing of this batch.
-            availableValue -= _revoke(
-                multiRequest.schemaUID,
-                moduleRecord.resolverUID,
-                multiRequest.data,
-                msg.sender,
-                availableValue,
-                last
-            );
+            availableValue -= _multiRevoke({
+                schemaUID: multiRequest.schemaUID,
+                resolverUID: moduleRecord.resolverUID,
+                data: multiRequest.data,
+                revoker: msg.sender,
+                availableValue: availableValue,
+                last: last
+            });
         }
     }
 
@@ -269,7 +290,7 @@ abstract contract Attestation is IAttestation, AttestationResolve, ReentrancyGua
         }
         // caching module address. gas bad
         address module = request.subject;
-        ModuleRecord storage moduleRecord = _getModule(module);
+        ModuleRecord storage moduleRecord = _getModule({ moduleAddress: module });
 
         // Ensure that attestation is for module that was registered.
         if (moduleRecord.implementation == ZERO_ADDRESS) {
@@ -283,7 +304,8 @@ abstract contract Attestation is IAttestation, AttestationResolve, ReentrancyGua
 
         // get salt used for SSTORE2 to avoid collisions during CREATE2
         bytes32 attestationSalt = AttestationLib.attestationSalt(attester, module);
-        AttestationDataRef sstore2Pointer = writeAttestationData(request.data, attestationSalt);
+        AttestationDataRef sstore2Pointer =
+            writeAttestationData({ attestationData: request.data, salt: attestationSalt });
 
         // write attestationdata with SSTORE2 to EVM, and prepare return value
         attestation = AttestationRecord({
@@ -303,6 +325,42 @@ abstract contract Attestation is IAttestation, AttestationResolve, ReentrancyGua
         emit Attested(module, attester, schemaUID, sstore2Pointer);
     }
 
+    function _revoke(
+        SchemaUID schemaUID,
+        RevocationRequestData memory request,
+        address revoker
+    )
+        internal
+        returns (AttestationRecord memory)
+    {
+        AttestationRecord storage attestation =
+            _moduleToAttesterToAttestations[request.subject][request.attester];
+
+        // Ensure that we aren't attempting to revoke a non-existing attestation.
+        if (AttestationDataRef.unwrap(attestation.dataPointer) == ZERO_ADDRESS) {
+            revert NotFound();
+        }
+
+        // Ensure that a wrong schema ID wasn't passed by accident.
+        if (attestation.schemaUID != schemaUID) {
+            revert InvalidSchema();
+        }
+
+        // Allow only original attesters to revoke their attestations.
+        if (attestation.attester != revoker) {
+            revert AccessDenied();
+        }
+
+        // Ensure that we aren't trying to revoke the same attestation twice.
+        if (attestation.revocationTime != 0) {
+            revert AlreadyRevoked();
+        }
+
+        attestation.revocationTime = _time();
+        emit Revoked(attestation.subject, revoker, attestation.schemaUID);
+        return attestation;
+    }
+
     /**
      * @dev Revokes an existing attestation to a specific schema.
      *
@@ -314,7 +372,7 @@ abstract contract Attestation is IAttestation, AttestationResolve, ReentrancyGua
      *
      * @return Returns the total sent ETH amount.
      */
-    function _revoke(
+    function _multiRevoke(
         SchemaUID schemaUID,
         ResolverUID resolverUID,
         RevocationRequestData[] memory data,
@@ -339,40 +397,20 @@ abstract contract Attestation is IAttestation, AttestationResolve, ReentrancyGua
         for (uint256 i; i < length; i = uncheckedInc(i)) {
             RevocationRequestData memory request = data[i];
 
-            {
-                AttestationRecord storage attestation =
-                    _moduleToAttesterToAttestations[request.subject][request.attester];
+            _moduleToAttesterToAttestations[request.subject][request.attester];
 
-                // Ensure that we aren't attempting to revoke a non-existing attestation.
-                if (AttestationDataRef.unwrap(attestation.dataPointer) == ZERO_ADDRESS) {
-                    revert NotFound();
-                }
-
-                // Ensure that a wrong schema ID wasn't passed by accident.
-                if (attestation.schemaUID != schemaUID) {
-                    revert InvalidSchema();
-                }
-
-                // Allow only original attesters to revoke their attestations.
-                if (attestation.attester != revoker) {
-                    revert AccessDenied();
-                }
-
-                // Ensure that we aren't trying to revoke the same attestation twice.
-                if (attestation.revocationTime != 0) {
-                    revert AlreadyRevoked();
-                }
-
-                // not caching time() to avoid "stack too deep"
-                attestation.revocationTime = _time();
-
-                attestations[i] = attestation;
-                values[i] = request.value;
-                emit Revoked(attestation.subject, revoker, attestation.schemaUID);
-            }
+            attestations[i] = _revoke({ schemaUID: schemaUID, request: request, revoker: revoker });
+            values[i] = request.value;
         }
 
-        return _resolveAttestations(resolverUID, attestations, values, true, availableValue, last);
+        return _resolveAttestations({
+            resolverUID: resolverUID,
+            attestations: attestations,
+            values: values,
+            isRevocation: true,
+            availableValue: availableValue,
+            last: last
+        });
     }
 
     /**

--- a/src/base/AttestationDelegation.sol
+++ b/src/base/AttestationDelegation.sol
@@ -107,8 +107,8 @@ abstract contract AttestationDelegation is IAttestation, Attestation {
 
             MultiDelegatedAttestationRequest calldata multiDelegatedRequest =
                 multiDelegatedRequests[i];
-            AttestationRequestData[] calldata data = multiDelegatedRequest.data;
-            uint256 dataLength = data.length;
+            AttestationRequestData[] calldata attestationRequestDatas = multiDelegatedRequest.data;
+            uint256 dataLength = attestationRequestDatas.length;
 
             // Ensure that no inputs are missing.
             if (dataLength == 0 || dataLength != multiDelegatedRequest.signatures.length) {
@@ -120,7 +120,7 @@ abstract contract AttestationDelegation is IAttestation, Attestation {
                 _verifyAttest(
                     DelegatedAttestationRequest({
                         schemaUID: multiDelegatedRequest.schemaUID,
-                        data: data[j],
+                        data: attestationRequestDatas[j],
                         signature: multiDelegatedRequest.signatures[j],
                         attester: multiDelegatedRequest.attester
                     })
@@ -131,7 +131,7 @@ abstract contract AttestationDelegation is IAttestation, Attestation {
             uint256 usedValue = _multiAttest({
                 schemaUID: multiDelegatedRequest.schemaUID,
                 resolverUID: moduleRecord.resolverUID,
-                attestationRequestDatas: data,
+                attestationRequestDatas: attestationRequestDatas,
                 attester: multiDelegatedRequest.attester,
                 availableValue: availableValue,
                 isLastAttestation: last
@@ -160,7 +160,7 @@ abstract contract AttestationDelegation is IAttestation, Attestation {
         _multiRevoke({
             schemaUID: request.schemaUID,
             resolverUID: moduleRecord.resolverUID,
-            data: data,
+            revocationRequestDatas: data,
             revoker: request.revoker,
             availableValue: msg.value,
             isLastRevocation: true
@@ -196,8 +196,8 @@ abstract contract AttestationDelegation is IAttestation, Attestation {
             }
 
             MultiDelegatedRevocationRequest memory multiDelegatedRequest = multiDelegatedRequests[i];
-            RevocationRequestData[] memory data = multiDelegatedRequest.data;
-            uint256 dataLength = data.length;
+            RevocationRequestData[] memory revocationRequestDatas = multiDelegatedRequest.data;
+            uint256 dataLength = revocationRequestDatas.length;
 
             // Ensure that no inputs are missing.
             if (dataLength == 0 || dataLength != multiDelegatedRequest.signatures.length) {
@@ -209,7 +209,7 @@ abstract contract AttestationDelegation is IAttestation, Attestation {
                 _verifyRevoke(
                     DelegatedRevocationRequest({
                         schemaUID: multiDelegatedRequest.schemaUID,
-                        data: data[j],
+                        data: revocationRequestDatas[j],
                         signature: multiDelegatedRequest.signatures[j],
                         revoker: multiDelegatedRequest.revoker
                     })
@@ -220,7 +220,7 @@ abstract contract AttestationDelegation is IAttestation, Attestation {
             availableValue -= _multiRevoke({
                 schemaUID: multiDelegatedRequest.schemaUID,
                 resolverUID: moduleRecord.resolverUID,
-                data: data,
+                revocationRequestDatas: revocationRequestDatas,
                 revoker: multiDelegatedRequest.revoker,
                 availableValue: availableValue,
                 isLastRevocation: last

--- a/src/base/AttestationDelegation.sol
+++ b/src/base/AttestationDelegation.sol
@@ -148,7 +148,9 @@ abstract contract AttestationDelegation is IAttestation, Attestation {
 
         ModuleRecord memory moduleRecord = _getModule(request.data.subject);
 
-        _revoke(request.schemaUID, moduleRecord.resolverUID, data, request.revoker, msg.value, true);
+        _multiRevoke(
+            request.schemaUID, moduleRecord.resolverUID, data, request.revoker, msg.value, true
+        );
     }
 
     /**
@@ -200,7 +202,7 @@ abstract contract AttestationDelegation is IAttestation, Attestation {
             }
 
             // Ensure to deduct the ETH that was forwarded to the resolver during the processing of this batch.
-            availableValue -= _revoke(
+            availableValue -= _multiRevoke(
                 multiDelegatedRequest.schemaUID,
                 moduleRecord.resolverUID,
                 data,

--- a/src/base/AttestationResolve.sol
+++ b/src/base/AttestationResolve.sol
@@ -30,21 +30,21 @@ abstract contract AttestationResolve is IAttestation, EIP712Verifier {
      * @dev Resolves a new attestation or a revocation of an existing attestation.
      *
      * @param resolverUID The schema of the attestation.
-     * @param attestation The data of the attestation to make/revoke.
+     * @param attestationRecord The data of the attestation to make/revoke.
      * @param value An explicit ETH amount to send to the resolver.
      * @param isRevocation Whether to resolve an attestation or its revocation.
      * @param availableValue The total available ETH amount that can be sent to the resolver.
-     * @param last Whether this is the last attestations/revocations set.
+     * @param isLastAttestation Whether this is the last attestations/revocations set.
      *
      * @return Returns the total sent ETH amount.
      */
     function _resolveAttestation(
         ResolverUID resolverUID,
-        AttestationRecord memory attestation,
+        AttestationRecord memory attestationRecord,
         uint256 value,
         bool isRevocation,
         uint256 availableValue,
-        bool last
+        bool isLastAttestation
     )
         internal
         returns (uint256)
@@ -54,9 +54,7 @@ abstract contract AttestationResolve is IAttestation, EIP712Verifier {
 
         if (address(resolverContract) == ZERO_ADDRESS) {
             // Ensure that we don't accept payments if there is no resolver.
-            if (value != 0) {
-                revert NotPayable();
-            }
+            if (value != 0) revert NotPayable();
 
             return 0;
         }
@@ -76,15 +74,17 @@ abstract contract AttestationResolve is IAttestation, EIP712Verifier {
             availableValue -= value;
         }
 
+        // Resolve a revocation with external IResolver
         if (isRevocation) {
-            if (!resolverContract.revoke{ value: value }(attestation)) {
+            if (!resolverContract.revoke{ value: value }(attestationRecord)) {
                 revert InvalidRevocation();
             }
-        } else if (!resolverContract.attest{ value: value }(attestation)) {
+            // Resolve an attestation with external IResolver
+        } else if (!resolverContract.attest{ value: value }(attestationRecord)) {
             revert InvalidAttestation();
         }
 
-        if (last) {
+        if (isLastAttestation) {
             _refund(availableValue);
         }
 
@@ -95,39 +95,42 @@ abstract contract AttestationResolve is IAttestation, EIP712Verifier {
      * @dev Resolves multiple attestations or revocations of existing attestations.
      *
      * @param resolverUID THe bytes32 uid of the resolver
-     * @param attestations The data of the attestations to make/revoke.
+     * @param attestationRecords The data of the attestations to make/revoke.
      * @param values Explicit ETH amounts to send to the resolver.
      * @param isRevocation Whether to resolve an attestation or its revocation.
      * @param availableValue The total available ETH amount that can be sent to the resolver.
-     * @param last Whether this is the last attestations/revocations set.
+     * @param isLast Whether this is the last attestations/revocations set.
      *
      * @return Returns the total sent ETH amount.
      */
     function _resolveAttestations(
         ResolverUID resolverUID,
-        AttestationRecord[] memory attestations,
+        AttestationRecord[] memory attestationRecords,
         uint256[] memory values,
         bool isRevocation,
         uint256 availableValue,
-        bool last
+        bool isLast
     )
         internal
         returns (uint256)
     {
-        uint256 length = attestations.length;
+        uint256 length = attestationRecords.length;
         if (length == 1) {
-            return _resolveAttestation(
-                resolverUID, attestations[0], values[0], isRevocation, availableValue, last
-            );
+            return _resolveAttestation({
+                resolverUID: resolverUID,
+                attestationRecord: attestationRecords[0],
+                value: values[0],
+                isRevocation: isRevocation,
+                availableValue: availableValue,
+                isLastAttestation: isLast
+            });
         }
-        ResolverRecord memory resolver = getResolver(resolverUID);
+        ResolverRecord memory resolver = getResolver({ resolverUID: resolverUID });
         IResolver resolverContract = resolver.resolver;
         if (address(resolverContract) == ZERO_ADDRESS) {
             // Ensure that we don't accept payments if there is no resolver.
             for (uint256 i; i < length; i = uncheckedInc(i)) {
-                if (values[i] != 0) {
-                    revert NotPayable();
-                }
+                if (values[i] != 0) revert NotPayable();
             }
 
             return 0;
@@ -144,9 +147,7 @@ abstract contract AttestationResolve is IAttestation, EIP712Verifier {
             }
 
             // Ensure that the attester/revoker doesn't try to spend more than available.
-            if (value > availableValue) {
-                revert InsufficientValue();
-            }
+            if (value > availableValue) revert InsufficientValue();
 
             // Ensure to deduct the sent value explicitly and add it to the total used value by the batch.
             unchecked {
@@ -155,16 +156,21 @@ abstract contract AttestationResolve is IAttestation, EIP712Verifier {
             }
         }
 
+        // Resolve a revocation with external IResolver
         if (isRevocation) {
-            if (!resolverContract.multiRevoke{ value: totalUsedValue }(attestations, values)) {
+            if (!resolverContract.multiRevoke{ value: totalUsedValue }(attestationRecords, values))
+            {
                 revert InvalidRevocations();
             }
-        } else if (!resolverContract.multiAttest{ value: totalUsedValue }(attestations, values)) {
+            // Resolve an attestation with external IResolver
+        } else if (
+            !resolverContract.multiAttest{ value: totalUsedValue }(attestationRecords, values)
+        ) {
             revert InvalidAttestations();
         }
 
-        if (last) {
-            _refund(availableValue);
+        if (isLast) {
+            _refund({ remainingValue: availableValue });
         }
 
         return totalUsedValue;
@@ -187,20 +193,24 @@ abstract contract AttestationResolve is IAttestation, EIP712Verifier {
     /**
      * @dev Internal function to get a schema record
      *
-     * @param uid The UID of the schema.
+     * @param schemaUID The UID of the schema.
      *
      * @return schemaRecord The schema record.
      */
-    function _getSchema(SchemaUID uid) internal view virtual returns (SchemaRecord storage);
+    function _getSchema(SchemaUID schemaUID) internal view virtual returns (SchemaRecord storage);
 
     /**
      * @dev Function to get a resolver record
      *
-     * @param uid The UID of the resolver.
+     * @param resolverUID The UID of the resolver.
      *
      * @return resolverRecord The resolver record.
      */
-    function getResolver(ResolverUID uid) public view virtual returns (ResolverRecord memory);
+    function getResolver(ResolverUID resolverUID)
+        public
+        view
+        virtual
+        returns (ResolverRecord memory);
 
     /**
      * @dev Internal function to get a module record

--- a/src/base/EIP712Verifier.sol
+++ b/src/base/EIP712Verifier.sol
@@ -17,7 +17,7 @@ import {
 /**
  * @title Singature Verifier. If provided signed is a contract, this function will fallback to ERC1271
  *
- * @author rhinestone | zeroknots.eth
+ * @author rhinestone | zeroknots.eth, Konrad Kopp (@kopy-kat)
  */
 abstract contract EIP712Verifier is EIP712 {
     // The hash of the data type used to relay calls to the attest function. It's the value of

--- a/src/base/Module.sol
+++ b/src/base/Module.sol
@@ -64,7 +64,13 @@ abstract contract Module is IModule, ReentrancyGuard {
 
         (moduleAddr,,) = code.deploy(deployParams, salt, msg.value);
 
-        _register(moduleAddr, msg.sender, resolver, resolverUID, metadata);
+        _register({
+            moduleAddress: moduleAddr,
+            sender: msg.sender,
+            resolver: resolver,
+            resolverUID: resolverUID,
+            metadata: metadata
+        });
         emit ModuleDeployed(moduleAddr, salt, ResolverUID.unwrap(resolverUID));
     }
 
@@ -89,7 +95,13 @@ abstract contract Module is IModule, ReentrancyGuard {
         bytes32 senderSalt = keccak256(abi.encodePacked(salt, msg.sender));
         moduleAddr = CREATE3.deploy(senderSalt, creationCode, msg.value);
 
-        _register(moduleAddr, msg.sender, resolver, resolverUID, metadata);
+        _register({
+            moduleAddress: moduleAddr,
+            sender: msg.sender,
+            resolver: resolver,
+            resolverUID: resolverUID,
+            metadata: metadata
+        });
         emit ModuleDeployed(moduleAddr, senderSalt, ResolverUID.unwrap(resolverUID));
     }
 
@@ -116,7 +128,13 @@ abstract contract Module is IModule, ReentrancyGuard {
         if (moduleAddr == ZERO_ADDRESS) revert InvalidDeployment();
         if (_isContract(moduleAddr) != true) revert InvalidDeployment();
 
-        _register(moduleAddr, msg.sender, resolver, resolverUID, metadata);
+        _register({
+            moduleAddress: moduleAddr,
+            sender: msg.sender,
+            resolver: resolver,
+            resolverUID: resolverUID,
+            metadata: metadata
+        });
         emit ModuleDeployedExternalFactory(moduleAddr, factory, ResolverUID.unwrap(resolverUID));
     }
 
@@ -178,7 +196,10 @@ abstract contract Module is IModule, ReentrancyGuard {
             metadata: metadata
         });
 
-        _resolveRegistration(resolver.resolver, moduleRegistration);
+        _resolveRegistration({
+            resolverContract: resolver.resolver,
+            moduleRegistration: moduleRegistration
+        });
 
         _modules[moduleAddress] = moduleRegistration;
     }
@@ -186,17 +207,17 @@ abstract contract Module is IModule, ReentrancyGuard {
     /**
      * @dev Resolves the module registration using the provided resolver.
      *
-     * @param resolver Resolver to validate the module registration.
+     * @param resolverContract Resolver to validate the module registration.
      * @param moduleRegistration Module record to be registered.
      */
     function _resolveRegistration(
-        IResolver resolver,
+        IResolver resolverContract,
         ModuleRecord memory moduleRegistration
     )
         private
     {
-        if (address(resolver) == ZERO_ADDRESS) return;
-        if (resolver.moduleRegistration(moduleRegistration) == false) {
+        if (address(resolverContract) == ZERO_ADDRESS) return;
+        if (resolverContract.moduleRegistration(moduleRegistration) == false) {
             revert InvalidDeployment();
         }
     }

--- a/src/base/Query.sol
+++ b/src/base/Query.sol
@@ -37,10 +37,14 @@ abstract contract Query is IQuery {
         AttestationRecord storage attestation = _getAttestation(module, attester);
 
         uint256 expirationTime = attestation.expirationTime;
-        attestedAt = expirationTime != 0 && expirationTime < block.timestamp ? 0 : attestation.time;
-        if (attestedAt == 0) revert AttestationNotFound();
+        attestedAt = expirationTime != ZERO_TIMESTAMP && expirationTime < block.timestamp
+            ? ZERO_TIMESTAMP
+            : attestation.time;
+        if (attestedAt == ZERO_TIMESTAMP) revert AttestationNotFound();
 
-        if (attestation.revocationTime != 0) revert RevokedAttestation(attestation.attester);
+        if (attestation.revocationTime != ZERO_TIMESTAMP) {
+            revert RevokedAttestation(attestation.attester);
+        }
     }
 
     /**
@@ -65,20 +69,21 @@ abstract contract Query is IQuery {
         attestedAtArray = new uint256[](attestersLength);
 
         for (uint256 i; i < attestersLength; i = uncheckedInc(i)) {
-            AttestationRecord storage attestation = _getAttestation(module, attesters[i]);
-            if (attestation.revocationTime != 0) {
+            AttestationRecord storage attestation =
+                _getAttestation({ moduleAddress: module, attester: attesters[i] });
+            if (attestation.revocationTime != ZERO_TIMESTAMP) {
                 revert RevokedAttestation(attestation.attester);
             }
 
             uint256 expirationTime = attestation.expirationTime;
-            if (expirationTime != 0 && expirationTime < timeNow) {
+            if (expirationTime != ZERO_TIMESTAMP && expirationTime < timeNow) {
                 revert AttestationNotFound();
             }
 
             uint256 attestationTime = attestation.time;
             attestedAtArray[i] = attestationTime;
 
-            if (attestationTime == 0) continue;
+            if (attestationTime == ZERO_TIMESTAMP) continue;
             if (threshold != 0) --threshold;
         }
         if (threshold == 0) return attestedAtArray;
@@ -106,17 +111,19 @@ abstract contract Query is IQuery {
         attestedAtArray = new uint256[](attestersLength);
 
         for (uint256 i; i < attestersLength; i = uncheckedInc(i)) {
-            AttestationRecord storage attestation = _getAttestation(module, attesters[i]);
+            AttestationRecord storage attestation =
+                _getAttestation({ moduleAddress: module, attester: attesters[i] });
 
             attestedAtArray[i] = attestation.time;
 
-            if (attestation.revocationTime != 0) continue;
+            if (attestation.revocationTime != ZERO_TIMESTAMP) continue;
 
             uint256 expirationTime = attestation.expirationTime;
-            uint256 attestedAt =
-                expirationTime != 0 && expirationTime < timeNow ? 0 : attestation.time;
+            uint256 attestedAt = expirationTime != ZERO_TIMESTAMP && expirationTime < timeNow
+                ? ZERO_TIMESTAMP
+                : attestation.time;
             attestedAtArray[i] = attestedAt;
-            if (attestedAt == 0) continue;
+            if (attestedAt == ZERO_TIMESTAMP) continue;
             if (threshold != 0) --threshold;
         }
         if (threshold == 0) return attestedAtArray;
@@ -162,14 +169,14 @@ abstract contract Query is IQuery {
      *
      * @dev This is a virtual function and is meant to be overridden in derived contracts.
      *
-     * @param module The address of the module for which the attestation is retrieved.
+     * @param moduleAddress The address of the module for which the attestation is retrieved.
      * @param attester The address of the attester whose record is being retrieved.
      *
      * @return Attestation record associated with the given module and attester.
      */
 
     function _getAttestation(
-        address module,
+        address moduleAddress,
         address attester
     )
         internal

--- a/src/base/Schema.sol
+++ b/src/base/Schema.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.19;
 
-import { AccessDenied, _time, ZERO_ADDRESS, InvalidResolver } from "../Common.sol";
+import { AccessDenied, _time, ZERO_TIMESTAMP, ZERO_ADDRESS, InvalidResolver } from "../Common.sol";
 import { ISchema, SchemaLib } from "../interface/ISchema.sol";
 import { IResolver } from "../external/IResolver.sol";
 import { ISchemaValidator } from "../external/ISchemaValidator.sol";
@@ -39,7 +39,7 @@ abstract contract Schema is ISchema {
         // Computing a unique ID for the schema using its properties
         uid = schemaRecord.getUID();
 
-        if (_schemas[uid].registeredAt != 0) revert AlreadyExists();
+        if (_schemas[uid].registeredAt != ZERO_TIMESTAMP) revert AlreadyExists();
 
         // Storing schema in the _schemas mapping
         _schemas[uid] = schemaRecord;

--- a/src/base/Schema.sol
+++ b/src/base/Schema.sol
@@ -90,12 +90,12 @@ abstract contract Schema is ISchema {
     /**
      * @dev Internal function to get a schema record
      *
-     * @param uid The UID of the schema.
+     * @param schemaUID The UID of the schema.
      *
      * @return schemaRecord The schema record.
      */
-    function _getSchema(SchemaUID uid) internal view virtual returns (SchemaRecord storage) {
-        return _schemas[uid];
+    function _getSchema(SchemaUID schemaUID) internal view virtual returns (SchemaRecord storage) {
+        return _schemas[schemaUID];
     }
 
     /**

--- a/src/interface/IAttestation.sol
+++ b/src/interface/IAttestation.sol
@@ -132,7 +132,7 @@ interface IAttestation {
     /**
      * @notice Handles a single delegated revocation request
      *
-     * @dev The function verifies the revocation, prepares data for the _revoke() function and revokes the requestZ
+     * @dev The function verifies the revocation, prepares data for the _multiRevoke() function and revokes the requestZ
      *
      * @param request A delegated revocation request
      */

--- a/src/interface/IAttestation.sol
+++ b/src/interface/IAttestation.sol
@@ -61,10 +61,10 @@ interface IAttestation {
      * @dev Emitted when an attestation has been revoked.
      *
      * @param subject The subject of the attestation.
-     * @param attester The attesting account.
+     * @param  revoker The attesting account.
      * @param schema The UID of the schema.
      */
-    event Revoked(address indexed subject, address indexed attester, SchemaUID indexed schema);
+    event Revoked(address indexed subject, address indexed revoker, SchemaUID indexed schema);
 
     /**
      * @dev Emitted when a data has been timestamped.


### PR DESCRIPTION
Renamed a lot of variables for better readability

added {} for all function calls

found a way to refactor the code, so single attestation/revocations no longer need the length 1 arrays