### PR TITLE
Test: Poc for reusing attestation data

### DIFF
--- a/src/base/Attestation.sol
+++ b/src/base/Attestation.sol
@@ -331,11 +331,12 @@ abstract contract Attestation is IAttestation, AttestationResolve, ReentrancyGua
             revert InvalidAttestation();
         }
 
-        // get salt used for SSTORE2 to avoid collisions during CREATE2
-        bytes32 attestationSalt = AttestationLib.attestationSalt(attester, module);
+        // salt = 0 so that attestation data can be reused
+        bytes32 attestationSalt = bytes32(0);
         AttestationDataRef sstore2Pointer = writeAttestationData({
             attestationData: attestationRequestData.data,
-            salt: attestationSalt
+            salt: attestationSalt,
+            thisAddress: address(this)
         });
 
         // write attestationdata with SSTORE2 to EVM, and prepare return value

--- a/test/gas/SStore2.t.sol
+++ b/test/gas/SStore2.t.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { Test } from "forge-std/Test.sol";
+import {
+    Attestation,
+    MultiDelegatedAttestationRequest,
+    AttestationRecord,
+    IAttestation,
+    InvalidSchema,
+    NotFound,
+    AccessDenied
+} from "../../src/base/Attestation.sol";
+
+import { ERC1271Attester, EXPECTED_SIGNATURE } from "../utils/ERC1271Attester.sol";
+
+import {
+    BaseTest,
+    RegistryTestLib,
+    RegistryInstance,
+    console2,
+    AttestationRequestData,
+    DelegatedAttestationRequest,
+    MockModuleWithArgs,
+    ResolverUID,
+    IResolver,
+    SchemaUID,
+    ISchemaValidator
+} from "../utils/BaseTest.t.sol";
+
+import {
+    MultiAttestationRequest,
+    MultiRevocationRequest,
+    RevocationRequestData,
+    RevocationRequest
+} from "../../src/DataTypes.sol";
+
+struct SampleAttestation {
+    address[] dependencies;
+    string comment;
+    string url;
+    bytes32 hash;
+    uint256 severity;
+}
+
+/// @title SStore2GasCalculations
+/// @author kopy-kat
+contract SStore2GasCalculations is BaseTest {
+    using RegistryTestLib for RegistryInstance;
+
+    function setUp() public virtual override {
+        super.setUp();
+    }
+
+    function testAttest() public {
+        AttestationRequestData memory attData = AttestationRequestData({
+            subject: defaultModule1,
+            expirationTime: uint48(200_000),
+            data: abi.encode(true),
+            value: 0
+        });
+
+        AttestationRequestData memory attData2 = AttestationRequestData({
+            subject: defaultModule2,
+            expirationTime: uint48(200_000),
+            data: abi.encode(true),
+            value: 0
+        });
+
+        uint256 gas = gasleft();
+        instance.newAttestation(defaultSchema1, attData);
+        // gas = gas - gasleft();
+        instance.newAttestation(defaultSchema1, attData2);
+        gas = gas - gasleft();
+        console2.log(gas);
+    }
+}


### PR DESCRIPTION
Just a test for the tradeoff of reusing attestation data. Gas comparisons:

Previously:
Cost of single attestation: 194_998
Cost of two attestations that have the same data: 365_939

Reusing attestation data:
Cost of single attestation: 197_708
Cost of two attestations that have the same data: 330_069

Differences:
Single: +2_710
Reuse: min -35_870 every time the data is reused (depends on data used, this is using `abi.encode(true)` so will most likely be much higher)