### PR TITLE
feat: adding default resolverUID

### DIFF
--- a/src/DataTypes.sol
+++ b/src/DataTypes.sol
@@ -34,7 +34,7 @@ struct SchemaRecord {
 }
 
 struct ResolverRecord {
-    IExternalResolver resolver; // Optional resolver.
+    IExternalResolver resolver; // resolver.
     address resolverOwner; // The address of the account used to register the resolver.
 }
 

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -7,7 +7,4 @@ import { SignedAttestation } from "./core/SignedAttestation.sol";
  * @author zeroknots
  */
 
-contract Registry is IRegistry, SignedAttestation {
-// TODO: should we create a default resolverUID thats address(0).
-// this will allow the registry to be usable right after deployment without any resolver
-}
+contract Registry is IRegistry, SignedAttestation { }

--- a/src/Registry.sol
+++ b/src/Registry.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.24;
 
-import { SignedAttestation } from "./core/SignedAttestation.sol";
 import { IRegistry } from "./IRegistry.sol";
+import { SignedAttestation } from "./core/SignedAttestation.sol";
 /**
  * @author zeroknots
  */

--- a/src/core/ModuleManager.sol
+++ b/src/core/ModuleManager.sol
@@ -49,6 +49,7 @@ abstract contract ModuleManager is IRegistry, ResolverManager {
         returns (address moduleAddress)
     {
         ResolverRecord storage $resolver = $resolvers[resolverUID];
+        // ensure that existing resolverUID was provided
         if ($resolver.resolverOwner == ZERO_ADDRESS) revert InvalidResolver($resolver.resolver);
 
         moduleAddress = initCode.deploy(salt);
@@ -72,8 +73,7 @@ abstract contract ModuleManager is IRegistry, ResolverManager {
      */
     function registerModule(ResolverUID resolverUID, address moduleAddress, bytes calldata metadata) external {
         ResolverRecord storage $resolver = $resolvers[resolverUID];
-
-        // ensure that non-zero resolverUID was provided
+        // ensure that existing resolverUID was provided
         if ($resolver.resolverOwner == ZERO_ADDRESS) revert InvalidResolver($resolver.resolver);
 
         ModuleRecord memory record = _storeModuleRecord({
@@ -101,7 +101,7 @@ abstract contract ModuleManager is IRegistry, ResolverManager {
         returns (address moduleAddress)
     {
         ResolverRecord storage $resolver = $resolvers[resolverUID];
-        if ($resolver.resolverOwner == ZERO_ADDRESS) revert InvalidResolverUID(resolverUID);
+        if ($resolver.resolverOwner == ZERO_ADDRESS) revert InvalidResolver($resolver.resolver);
         // prevent someone from calling a registry function pretending its a factory
         if (factory == address(this)) revert FactoryCallFailed(factory);
         // call external factory to deploy module

--- a/src/core/ModuleManager.sol
+++ b/src/core/ModuleManager.sol
@@ -131,8 +131,6 @@ abstract contract ModuleManager is IRegistry, ResolverManager {
         internal
         returns (ModuleRecord memory moduleRegistration)
     {
-        // ensure that non-zero resolverUID was provided
-        if (resolverUID == EMPTY_RESOLVER_UID) revert InvalidDeployment();
         // ensure moduleAddress is not already registered
         if ($moduleAddrToRecords[moduleAddress].resolverUID != EMPTY_RESOLVER_UID) {
             revert AlreadyRegistered(moduleAddress);

--- a/src/core/ResolverManager.sol
+++ b/src/core/ResolverManager.sol
@@ -12,6 +12,11 @@ abstract contract ResolverManager is IRegistry {
 
     mapping(ResolverUID uid => ResolverRecord resolver) internal $resolvers;
 
+    constructor() {
+        ResolverRecord storage $resolver = $resolvers[ResolverUID.wrap(bytes32(0))];
+        $resolver.resolverOwner = address(this);
+    }
+
     /**
      * @dev Modifier to require that the caller is the owner of a resolver
      *

--- a/src/lib/ModuleDeploymentLib.sol
+++ b/src/lib/ModuleDeploymentLib.sol
@@ -71,6 +71,4 @@ library ModuleDeploymentLib {
             )
         );
     }
-
-    error InvalidDeployment();
 }

--- a/src/lib/ModuleDeploymentLib.sol
+++ b/src/lib/ModuleDeploymentLib.sol
@@ -5,11 +5,11 @@ pragma solidity ^0.8.24;
  * @title ModuleDeploymentLib
  * @dev A library that can be used to deploy the Registry
  * @author zeroknots
+ *     source: https://github.com/0age/metamorphic/blob/master/contracts/ImmutableCreate2Factory.sol#L194-L203
  */
 library ModuleDeploymentLib {
     error InvalidSalt();
     error InvalidAddress();
-    // source: https://github.com/0age/metamorphic/blob/master/contracts/ImmutableCreate2Factory.sol#L194-L203
 
     modifier containsCaller(bytes32 salt) {
         // prevent contract submissions from being stolen from tx.pool by requiring

--- a/src/lib/StubLib.sol
+++ b/src/lib/StubLib.sol
@@ -108,7 +108,7 @@ library StubLib {
     {
         IExternalResolver resolverContract = $resolver.resolver;
 
-        if (address(resolverContract) != ZERO_ADDRESS) return;
+        if (address(resolverContract) == ZERO_ADDRESS) return;
 
         if (resolverContract.resolveModuleRegistration({ sender: msg.sender, moduleAddress: moduleAddress, record: moduleRecord }) == false)
         {

--- a/test/ModuleRegistration.t.sol
+++ b/test/ModuleRegistration.t.sol
@@ -42,7 +42,7 @@ contract ModuleRegistrationTest is BaseTest {
     function test_WhenRegisteringAModuleOnAnInvalidResolverUID() external prankWithAccount(moduleDev1) {
         MockModule newModule = new MockModule();
         // It should revert.
-        ResolverUID invalidUID = ResolverUID.wrap(hex"00");
+        ResolverUID invalidUID = ResolverUID.wrap(hex"01");
         vm.expectRevert(abi.encodeWithSelector(IRegistry.InvalidResolver.selector, address(0)));
         registry.registerModule(invalidUID, address(newModule), "");
 
@@ -102,5 +102,16 @@ contract ModuleRegistrationTest is BaseTest {
     function test_WhenUsingRegistryASFactory() public {
         vm.expectRevert();
         registry.deployViaFactory(address(registry), "", "", defaultResolverUID);
+    }
+
+    function test_WhenUsingDefaultResolverUID() public prankWithAccount(moduleDev1) {
+        bytes32 salt = bytes32(abi.encodePacked(address(moduleDev1.addr), bytes12(0)));
+
+        bytes memory bytecode = type(MockModule).creationCode;
+
+        ResolverUID nullUID = ResolverUID.wrap(bytes32(0));
+        address moduleAddr = registry.deployModule(salt, nullUID, bytecode, "");
+        ModuleRecord memory record = registry.findModule(moduleAddr);
+        assertTrue(record.resolverUID == nullUID);
     }
 }


### PR DESCRIPTION
Added a constructor in ResolverManager that adds a valid ResolverUID(0).

This should be helpful to get the registry to a default operational state right after registration