### PR TITLE
feat: add bytes calldata param to pass arbitrary data to resolvers

### DIFF
--- a/src/IRegistry.sol
+++ b/src/IRegistry.sol
@@ -236,12 +236,14 @@ interface IRegistry is IERC7484 {
      * @param metadata The metadata to be stored on the registry.
      *            This field is optional, and might be used by the module developer to store additional
      *            information about the module or facilitate business logic with the Resolver stub
+     * @param resolverContext bytes that will be passed to the resolver contract
      */
     function deployModule(
         bytes32 salt,
         ResolverUID resolverUID,
         bytes calldata initCode,
-        bytes calldata metadata
+        bytes calldata metadata,
+        bytes calldata resolverContext
     )
         external
         payable
@@ -260,7 +262,8 @@ interface IRegistry is IERC7484 {
         address factory,
         bytes calldata callOnFactory,
         bytes calldata metadata,
-        ResolverUID resolverUID
+        ResolverUID resolverUID,
+        bytes calldata resolverContext
     )
         external
         payable
@@ -278,8 +281,15 @@ interface IRegistry is IERC7484 {
      * @param metadata The metadata to be stored on the registry.
      *            This field is optional, and might be used by the module developer to store additional
      *            information about the module or facilitate business logic with the Resolver stub
+     * @param resolverContext bytes that will be passed to the resolver contract
      */
-    function registerModule(ResolverUID resolverUID, address moduleAddress, bytes calldata metadata) external;
+    function registerModule(
+        ResolverUID resolverUID,
+        address moduleAddress,
+        bytes calldata metadata,
+        bytes calldata resolverContext
+    )
+        external;
 
     /**
      * in conjunction with the deployModule() function, this function let's you

--- a/src/core/ModuleManager.sol
+++ b/src/core/ModuleManager.sol
@@ -41,7 +41,8 @@ abstract contract ModuleManager is IRegistry, ResolverManager {
         bytes32 salt,
         ResolverUID resolverUID,
         bytes calldata initCode,
-        bytes calldata metadata
+        bytes calldata metadata,
+        bytes calldata resolverContext
     )
         external
         payable
@@ -56,7 +57,11 @@ abstract contract ModuleManager is IRegistry, ResolverManager {
         ModuleRecord memory record =
             _storeModuleRecord({ moduleAddress: moduleAddress, sender: msg.sender, resolverUID: resolverUID, metadata: metadata });
 
-        record.requireExternalResolverOnModuleRegistration({ moduleAddress: moduleAddress, $resolver: $resolver });
+        record.requireExternalResolverOnModuleRegistration({
+            moduleAddress: moduleAddress,
+            $resolver: $resolver,
+            resolverContext: resolverContext
+        });
     }
 
     /**
@@ -69,7 +74,14 @@ abstract contract ModuleManager is IRegistry, ResolverManager {
     /**
      * @inheritdoc IRegistry
      */
-    function registerModule(ResolverUID resolverUID, address moduleAddress, bytes calldata metadata) external {
+    function registerModule(
+        ResolverUID resolverUID,
+        address moduleAddress,
+        bytes calldata metadata,
+        bytes calldata resolverContext
+    )
+        external
+    {
         ResolverRecord storage $resolver = $resolvers[resolverUID];
 
         // ensure that non-zero resolverUID was provided
@@ -83,7 +95,11 @@ abstract contract ModuleManager is IRegistry, ResolverManager {
         });
 
         // resolve module registration
-        record.requireExternalResolverOnModuleRegistration({ moduleAddress: moduleAddress, $resolver: $resolver });
+        record.requireExternalResolverOnModuleRegistration({
+            moduleAddress: moduleAddress,
+            $resolver: $resolver,
+            resolverContext: resolverContext
+        });
     }
 
     /**
@@ -93,7 +109,8 @@ abstract contract ModuleManager is IRegistry, ResolverManager {
         address factory,
         bytes calldata callOnFactory,
         bytes calldata metadata,
-        ResolverUID resolverUID
+        ResolverUID resolverUID,
+        bytes calldata resolverContext
     )
         external
         payable
@@ -118,7 +135,11 @@ abstract contract ModuleManager is IRegistry, ResolverManager {
             metadata: metadata
         });
 
-        record.requireExternalResolverOnModuleRegistration({ moduleAddress: moduleAddress, $resolver: $resolver });
+        record.requireExternalResolverOnModuleRegistration({
+            moduleAddress: moduleAddress,
+            $resolver: $resolver,
+            resolverContext: resolverContext
+        });
     }
 
     /**

--- a/src/external/IExternalResolver.sol
+++ b/src/external/IExternalResolver.sol
@@ -44,7 +44,8 @@ interface IExternalResolver is IERC165 {
     function resolveModuleRegistration(
         address sender,
         address moduleAddress,
-        ModuleRecord calldata record
+        ModuleRecord calldata record,
+        bytes calldata resolverContext
     )
         external
         payable

--- a/src/external/examples/TokenizedResolver.sol
+++ b/src/external/examples/TokenizedResolver.sol
@@ -25,7 +25,8 @@ contract TokenizedResolver is ResolverBase {
     function resolveModuleRegistration(
         address sender,
         address moduleAddress,
-        ModuleRecord calldata record
+        ModuleRecord calldata record,
+        bytes calldata resolverContext
     )
         external
         payable

--- a/src/lib/StubLib.sol
+++ b/src/lib/StubLib.sol
@@ -146,7 +146,8 @@ library StubLib {
     function requireExternalResolverOnModuleRegistration(
         ModuleRecord memory moduleRecord,
         address moduleAddress,
-        ResolverRecord storage $resolver
+        ResolverRecord storage $resolver,
+        bytes calldata resolverContext
     )
         internal
     {
@@ -154,8 +155,12 @@ library StubLib {
 
         if (
             address(resolverContract) != ZERO_ADDRESS
-                && resolverContract.resolveModuleRegistration({ sender: msg.sender, moduleAddress: moduleAddress, record: moduleRecord })
-                    == false
+                && resolverContract.resolveModuleRegistration({
+                    sender: msg.sender,
+                    moduleAddress: moduleAddress,
+                    record: moduleRecord,
+                    resolverContext: resolverContext
+                }) == false
         ) {
             revert IRegistry.ExternalError_ModuleRegistration();
         }

--- a/test/Attestation.t.sol
+++ b/test/Attestation.t.sol
@@ -32,7 +32,7 @@ contract AttestationTest is BaseTest {
 
     function test_WhenAttestingWithNoAttestationData() public prankWithAccount(attester1) {
         address module = address(new MockModule());
-        registry.registerModule(defaultResolverUID, module, "");
+        registry.registerModule(defaultResolverUID, module, "", "");
         uint32[] memory types = new uint32[](1);
         AttestationRequest memory request = mockAttestation(module, uint48(block.timestamp + 1), "", types);
         // It should store.
@@ -154,7 +154,7 @@ contract AttestationTest is BaseTest {
 
     function test_WhenReAttestingToARevokedAttestation() public prankWithAccount(attester1) {
         address module = address(new MockModule());
-        registry.registerModule(defaultResolverUID, module, "");
+        registry.registerModule(defaultResolverUID, module, "", "");
         uint32[] memory types = new uint32[](1);
         AttestationRequest memory request = mockAttestation(module, uint48(block.timestamp + 1), "", types);
         // It should store.

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -94,11 +94,11 @@ contract BaseTest is Test {
         defaultSchemaUID = registry.registerSchema(defaultSchema, IExternalSchemaValidator(address(schemaValidatorTrue)));
 
         vm.prank(moduleDev1.addr);
-        registry.registerModule(defaultResolverUID, address(module1), "");
+        registry.registerModule(defaultResolverUID, address(module1), "", "");
         vm.prank(moduleDev2.addr);
-        registry.registerModule(defaultResolverUID, address(module2), "");
+        registry.registerModule(defaultResolverUID, address(module2), "", "");
         vm.prank(moduleDev1.addr);
-        registry.registerModule(differentResolverUID, address(module3), "");
+        registry.registerModule(differentResolverUID, address(module3), "", "");
 
         AttestationRequest memory req = AttestationRequest({
             moduleAddr: address(module1),

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -25,7 +25,7 @@ contract FactoryTest is BaseTest {
         vm.startPrank(address(0x05a40beAF368EB6b2bc5665901a885C044C19346));
         address moduleAddr = registry.calcModuleAddress(salt, type(MockModuleFoo).creationCode);
 
-        address deployedAddr = registry.deployModule(salt, defaultResolverUID, type(MockModuleFoo).creationCode, "");
+        address deployedAddr = registry.deployModule(salt, defaultResolverUID, type(MockModuleFoo).creationCode, "", "");
         vm.stopPrank();
         assertTrue(moduleAddr == deployedAddr);
     }

--- a/test/ModuleRegistration.t.sol
+++ b/test/ModuleRegistration.t.sol
@@ -22,7 +22,7 @@ contract ModuleRegistrationTest is BaseTest {
 
         bytes memory bytecode = type(MockModule).creationCode;
 
-        address moduleAddr = registry.deployModule(salt, defaultResolverUID, bytecode, "");
+        address moduleAddr = registry.deployModule(salt, defaultResolverUID, bytecode, "", "");
         ModuleRecord memory record = registry.findModule(moduleAddr);
         assertTrue(record.resolverUID == defaultResolverUID);
     }
@@ -33,7 +33,7 @@ contract ModuleRegistrationTest is BaseTest {
         bytes memory bytecode = type(MockModuleWithArgs).creationCode;
         bytes memory initCode = abi.encodePacked(bytecode, abi.encode(313_131));
 
-        address moduleAddr = registry.deployModule(salt, defaultResolverUID, initCode, "");
+        address moduleAddr = registry.deployModule(salt, defaultResolverUID, initCode, "", "");
 
         address moduleAddrCalc = registry.calcModuleAddress(salt, initCode);
         assertTrue(moduleAddr == moduleAddrCalc);
@@ -44,18 +44,18 @@ contract ModuleRegistrationTest is BaseTest {
         // It should revert.
         ResolverUID invalidUID = ResolverUID.wrap(hex"00");
         vm.expectRevert(abi.encodeWithSelector(IRegistry.InvalidResolver.selector, address(0)));
-        registry.registerModule(invalidUID, address(newModule), "");
+        registry.registerModule(invalidUID, address(newModule), "", "");
 
         invalidUID = ResolverUID.wrap("1");
         vm.expectRevert(abi.encodeWithSelector(IRegistry.InvalidResolver.selector, address(0)));
-        registry.registerModule(invalidUID, address(newModule), "");
+        registry.registerModule(invalidUID, address(newModule), "", "");
     }
 
     function test_WhenRegisteringAModuleOnAValidResolverUID() external prankWithAccount(moduleDev1) {
         // It should register.
 
         MockModule newModule = new MockModule();
-        registry.registerModule(defaultResolverUID, address(newModule), "");
+        registry.registerModule(defaultResolverUID, address(newModule), "", "");
     }
 
     function test_WhenRegisteringAModuleOnAInValidResolverUID() external prankWithAccount(moduleDev1) {
@@ -63,16 +63,16 @@ contract ModuleRegistrationTest is BaseTest {
 
         MockModule newModule = new MockModule();
         vm.expectRevert(abi.encodeWithSelector(IRegistry.InvalidResolver.selector, address(0)));
-        registry.registerModule(ResolverUID.wrap(bytes32("foobar")), address(newModule), "");
+        registry.registerModule(ResolverUID.wrap(bytes32("foobar")), address(newModule), "", "");
     }
 
     function test_WhenRegisteringTwoModulesWithTheSameBytecode() external prankWithAccount(moduleDev1) {
         MockModule newModule = new MockModule();
         // It should revert.
-        registry.registerModule(defaultResolverUID, address(newModule), "");
+        registry.registerModule(defaultResolverUID, address(newModule), "", "");
 
         vm.expectRevert(abi.encodeWithSelector(IRegistry.AlreadyRegistered.selector, address(newModule)));
-        registry.registerModule(defaultResolverUID, address(newModule), "");
+        registry.registerModule(defaultResolverUID, address(newModule), "", "");
     }
 
     function test_WhenRegisteringViaFactory() public {
@@ -82,25 +82,25 @@ contract ModuleRegistrationTest is BaseTest {
 
         factory.setReturnAddress(address(0));
         vm.expectRevert();
-        registry.deployViaFactory(address(factory), abi.encodeCall(factory.deployFn, ()), "", defaultResolverUID);
+        registry.deployViaFactory(address(factory), abi.encodeCall(factory.deployFn, ()), "", defaultResolverUID, "");
 
         factory.setReturnAddress(address(1));
         vm.expectRevert();
 
-        registry.deployViaFactory(address(factory), abi.encodeCall(factory.deployFn, ()), "", defaultResolverUID);
+        registry.deployViaFactory(address(factory), abi.encodeCall(factory.deployFn, ()), "", defaultResolverUID, "");
 
         MockModule newModule = new MockModule();
         factory.setReturnAddress(address(newModule));
-        registry.deployViaFactory(address(factory), abi.encodeCall(factory.deployFn, ()), "", defaultResolverUID);
+        registry.deployViaFactory(address(factory), abi.encodeCall(factory.deployFn, ()), "", defaultResolverUID, "");
     }
 
     function test_WhenUsingInvalidFactory() public {
         vm.expectRevert();
-        registry.deployViaFactory(address(0), "", "", defaultResolverUID);
+        registry.deployViaFactory(address(0), "", "", defaultResolverUID, "");
     }
 
     function test_WhenUsingRegistryASFactory() public {
         vm.expectRevert();
-        registry.deployViaFactory(address(registry), "", "", defaultResolverUID);
+        registry.deployViaFactory(address(registry), "", "", defaultResolverUID, "");
     }
 }

--- a/test/invariance/Handler.t.sol
+++ b/test/invariance/Handler.t.sol
@@ -66,7 +66,7 @@ contract Handler is CommonBase, StdCheats, StdUtils {
         vm.etch(moduleAddr, bytecode);
         ResolverUID uid = _pickRandomResolverUID(randomResolverNr);
 
-        REGISTRY.registerModule(uid, moduleAddr, metadata);
+        REGISTRY.registerModule(uid, moduleAddr, metadata, "");
     }
 
     function _pickTypes() private pure returns (ModuleType[] memory ret) {
@@ -117,6 +117,6 @@ contract Handler is CommonBase, StdCheats, StdUtils {
     function handle_registerModuleWithFactory(uint256 randomResolverNr, bytes calldata bytecode, uint256 value) external {
         vm.deal(address(this), value);
         ResolverUID uid = _pickRandomResolverUID(randomResolverNr);
-        REGISTRY.deployViaFactory{ value: value }(address(FACTORY), abi.encodeCall(MockFactory.deploy, (bytecode)), "", uid);
+        REGISTRY.deployViaFactory{ value: value }(address(FACTORY), abi.encodeCall(MockFactory.deploy, (bytecode)), "", uid, "");
     }
 }

--- a/test/mocks/MockResolver.sol
+++ b/test/mocks/MockResolver.sol
@@ -49,7 +49,8 @@ contract MockResolver is IExternalResolver {
     function resolveModuleRegistration(
         address sender,
         address moduleRecord,
-        ModuleRecord calldata record
+        ModuleRecord calldata record,
+        bytes calldata resolverContext
     )
         external
         payable


### PR DESCRIPTION
To allow monetization flows of modules on resolvers, I added a simple calldata param to the registry's module deployment functions.

Note: this data is simply passed through the registry to the resolver, no sstores or sloads occurs based on this data